### PR TITLE
edgeTransport 2.0 release

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '10135247824'
+ValidationKey: '1195260'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.5.0.9002
-date-released: '2024-07-08'
+version: 0.6.0
+date-released: '2024-07-17'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.5.0.9002
+Version: 0.6.0
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -25,4 +25,4 @@ Imports:
     magrittr,
     quitte,
     data.table
-Date: 2024-07-08
+Date: 2024-07-17

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.5.0.9002**
+R package **mrtransport**, version **0.6.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrtransport)](https://cran.r-project.org/package=mrtransport)  [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel Jj, Dirnaichner A (2024). _mrtransport: Input data generation for the EDGE-Transport model_. R package version 0.5.0.9002, <https://github.com/pik-piam/mrtransport>.
+Hoppe J, Muessel Jj, Dirnaichner A (2024). _mrtransport: Input data generation for the EDGE-Transport model_. R package version 0.6.0, <https://github.com/pik-piam/mrtransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrtransport: Input data generation for the EDGE-Transport model},
   author = {Johanna Hoppe and Jarusch jarusch.muessel@pik-potsdam.de Muessel and Alois Dirnaichner},
   year = {2024},
-  note = {R package version 0.5.0.9002},
+  note = {R package version 0.6.0},
   url = {https://github.com/pik-piam/mrtransport},
 }
 ```


### PR DESCRIPTION
mrtransport is a madrat input data package for transport standalone input data
and is used by edgeTransport 2.0