### PR TITLE
BevPhaseIn

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1195260'
+ValidationKey: '1216950'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1216950'
+ValidationKey: '1397550'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: 7910e0323d7213f34275a7a562b9ef0fde8ce1b9  # frozen: v0.4.2
+    rev: bae853d82da476eee0e0a57960ee6b741a3b3fb7  # frozen: v0.4.3
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.6.1
-date-released: '2024-08-15'
+version: 0.7.0
+date-released: '2024-08-30'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.
 authors:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.6.0
-date-released: '2024-07-17'
+version: 0.6.1
+date-released: '2024-08-15'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.6.0
+Version: 0.6.1
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -12,7 +12,7 @@ License: LGPL-3 | file LICENSE
 URL: https://github.com/pik-piam/mrtransport
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Suggests: 
     covr
 Imports:
@@ -25,4 +25,4 @@ Imports:
     magrittr,
     quitte,
     data.table
-Date: 2024-07-17
+Date: 2024-08-15

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.6.1
+Version: 0.7.0
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -25,4 +25,4 @@ Imports:
     magrittr,
     quitte,
     data.table
-Date: 2024-08-15
+Date: 2024-08-30

--- a/R/calcEdgeTransportSAinputs.R
+++ b/R/calcEdgeTransportSAinputs.R
@@ -6,6 +6,7 @@
 #' @import data.table
 #' @importFrom rmndt approx_dt
 #' @importFrom madrat readSource calcOutput
+#' @importFrom magclass time_interpolate
 
 calcEdgeTransportSAinputs <- function(subtype, SSPscen = "SSP2EU", IEAharm = TRUE) { # nolint: cyclocomp_linter
 

--- a/R/toolAdjustAnnualMileage.R
+++ b/R/toolAdjustAnnualMileage.R
@@ -36,14 +36,17 @@ toolAdjustAnnualMileage <- function(dt, completeData, filter, ariadneAdjustments
   dt[, unit := "vehkm/veh/yr"][, variable := "Annual mileage"][, check := NULL]
 
   # Average first within regions over technologies -> e.g. BEV gets the same value as other technologies
-  dt[, min := if (!all(is.na(value))) min(value, na.rm = TRUE), by = c("region", "period", "univocalName")]
+  # Take min over technologies for BEV
+  dt[, min := ifelse(!all(is.na(value)), min(value, na.rm = TRUE), NA_real_), by = c("region", "period", "univocalName")]
   dt[, value := ifelse(
-    technology == "BEV" & is.na(value) & !is.infinite(min), min, value),
+    technology == "BEV" & is.na(value), min, value),
     by = c("region", "period", "univocalName")]
   dt[, min := NULL]
+  # Take mean over technologies for all other technologies
   dt[, value := ifelse(
     !(technology == "BEV") & is.na(value), mean(value, na.rm = TRUE), value),
     by = c("region", "period", "univocalName")]
+  # If there are still NAs take mean over regions by technology
   dt[, value := ifelse(is.na(value), mean(value, na.rm = TRUE), value),
      by = c("period", "technology", "univocalName")]
 

--- a/R/toolAdjustAnnualMileage.R
+++ b/R/toolAdjustAnnualMileage.R
@@ -30,14 +30,15 @@ toolAdjustAnnualMileage <- function(dt, completeData, filter, ariadneAdjustments
   completeData <- completeData[!univocalName %in% c("Cycle", "Walk")]
   dt <- merge.data.table(completeData, dt, all = TRUE)
   # For some regions an annual mileage is provided for certain vehicle types, but no demand.
-  # These values need to be deleted
+  # These values need to be deleted 
   dt <- dt[!is.na(check)]
   # update variable and unit for introduced NAs
   dt[, unit := "vehkm/veh/yr"][, variable := "Annual mileage"][, check := NULL]
-  # Average first within regions over technologies -> e.g. BEV gets the same value as other technologies
-  dt[, value := ifelse(is.na(value), mean(value, na.rm = TRUE), value), by = c("region", "period", "univocalName")]
-  # If there are still NAs, average over regions -> e.g. ICE in FRA gets the same value as ICE in DEU
-  dt[, value := ifelse(is.na(value), mean(value, na.rm = TRUE), value), by = c("period", "univocalName", "technology")]
+  # Not used atm. Alternative would be to use min() instead of mean() here, as BEV shares for DEU became to high with this version: Average first within regions over technologies -> e.g. BEV gets the same value as other technologies
+  #dt[, value := ifelse(is.na(value), mean(value, na.rm = TRUE), value), by = c("region", "period", "univocalName")]
+  # If there are still NAs, average over univocalNames (before it was and univocalName regions -> e.g. ICE in FRA gets the same value as ICE in DEU)
+  dt[, value := ifelse(is.na(value), mean(value, na.rm = TRUE), value), by = c("period", "univocalName")]
+
 
 
 #b) Annual Mileage for Trucks is missing completely - insert assumptions made by Alois in 2022 (probably from ARIADNE)

--- a/R/toolAdjustAnnualMileage.R
+++ b/R/toolAdjustAnnualMileage.R
@@ -30,16 +30,22 @@ toolAdjustAnnualMileage <- function(dt, completeData, filter, ariadneAdjustments
   completeData <- completeData[!univocalName %in% c("Cycle", "Walk")]
   dt <- merge.data.table(completeData, dt, all = TRUE)
   # For some regions an annual mileage is provided for certain vehicle types, but no demand.
-  # These values need to be deleted 
+  # These values need to be deleted
   dt <- dt[!is.na(check)]
   # update variable and unit for introduced NAs
   dt[, unit := "vehkm/veh/yr"][, variable := "Annual mileage"][, check := NULL]
-  # Not used atm. Alternative would be to use min() instead of mean() here, as BEV shares for DEU became to high with this version: Average first within regions over technologies -> e.g. BEV gets the same value as other technologies
-  #dt[, value := ifelse(is.na(value), mean(value, na.rm = TRUE), value), by = c("region", "period", "univocalName")]
-  # If there are still NAs, average over univocalNames (before it was and univocalName regions -> e.g. ICE in FRA gets the same value as ICE in DEU)
-  dt[, value := ifelse(is.na(value), mean(value, na.rm = TRUE), value), by = c("period", "univocalName")]
 
-
+  # Average first within regions over technologies -> e.g. BEV gets the same value as other technologies
+  dt[, min := if (!all(is.na(value))) min(value, na.rm = TRUE), by = c("region", "period", "univocalName")]
+  dt[, value := ifelse(
+    technology == "BEV" & is.na(value) & !is.infinite(min), min, value),
+    by = c("region", "period", "univocalName")]
+  dt[, min := NULL]
+  dt[, value := ifelse(
+    !(technology == "BEV") & is.na(value), mean(value, na.rm = TRUE), value),
+    by = c("region", "period", "univocalName")]
+  dt[, value := ifelse(is.na(value), mean(value, na.rm = TRUE), value),
+     by = c("period", "technology", "univocalName")]
 
 #b) Annual Mileage for Trucks is missing completely - insert assumptions made by Alois in 2022 (probably from ARIADNE)
   annualMileageTrucks <- fread(

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.6.0**
+R package **mrtransport**, version **0.6.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrtransport)](https://cran.r-project.org/package=mrtransport)  [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel Jj, Dirnaichner A (2024). _mrtransport: Input data generation for the EDGE-Transport model_. R package version 0.6.0, <https://github.com/pik-piam/mrtransport>.
+Hoppe J, Muessel Jj, Dirnaichner A (2024). _mrtransport: Input data generation for the EDGE-Transport model_. R package version 0.6.1, <https://github.com/pik-piam/mrtransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrtransport: Input data generation for the EDGE-Transport model},
   author = {Johanna Hoppe and Jarusch jarusch.muessel@pik-potsdam.de Muessel and Alois Dirnaichner},
   year = {2024},
-  note = {R package version 0.6.0},
+  note = {R package version 0.6.1},
   url = {https://github.com/pik-piam/mrtransport},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.6.1**
+R package **mrtransport**, version **0.7.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrtransport)](https://cran.r-project.org/package=mrtransport)  [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel Jj, Dirnaichner A (2024). _mrtransport: Input data generation for the EDGE-Transport model_. R package version 0.6.1, <https://github.com/pik-piam/mrtransport>.
+Hoppe J, Muessel Jj, Dirnaichner A (2024). _mrtransport: Input data generation for the EDGE-Transport model_. R package version 0.7.0, <https://github.com/pik-piam/mrtransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrtransport: Input data generation for the EDGE-Transport model},
   author = {Johanna Hoppe and Jarusch jarusch.muessel@pik-potsdam.de Muessel and Alois Dirnaichner},
   year = {2024},
-  note = {R package version 0.6.1},
+  note = {R package version 0.7.0},
   url = {https://github.com/pik-piam/mrtransport},
 }
 ```


### PR DESCRIPTION
As BEV-sales were too progressive I limited them by doing three adjustments: 
- parameters of the policyMask
- start values for incoCosts 
- filling missing values for annual mileage data for technology == "BEV" using min() instead of using mean()
I did the latter because the annual mileage impacts the annuity, CAPEX, and, hence, fuel share. 

The corresponding edgeT PR can be found [here](https://github.com/pik-piam/edgeTransport/pull/272). 

The compScens can be found here: `/p/projects/edget/PRchangeLog/BEVPhaseIn`