### PR TITLE
avoid ASCII characters

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,9 +1,8 @@
-ValidationKey: '1419006'
+ValidationKey: '1439208'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'
-- Found the following file with non-ASCII characters
 AcceptedNotes: 'Undefined global functions or variables:'
 allowLinterWarnings: yes
 enforceVersionUpdate: no

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.7.1
-date-released: '2024-09-20'
+version: 0.7.2
+date-released: '2024-09-23'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.7.1
+Version: 0.7.2
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -17,7 +17,7 @@ Depends:
     madrat (>= 3.7.1),
     mrdrivers (>= 2.0.0) 
 Imports:
-    GDPuc,
+    GDPuc (>= 1.1.0),
     magclass,
     rmndt,
     stringr,
@@ -26,5 +26,5 @@ Imports:
     magrittr,
     quitte,
     data.table
-Date: 2024-09-20
+Date: 2024-09-23
 

--- a/R/convertPSI.R
+++ b/R/convertPSI.R
@@ -35,7 +35,7 @@ convertPSI <- function(x, subtype) {
       # PSI CAPEX need to be transformed from EUR 2017 to USD 2017
       x <- GDPuc::convertGDP(
         gdp = x,
-        unit_in = "constant 2017 €",
+        unit_in = "constant 2017 EUR",
         unit_out = mrdrivers::toolGetUnitDollar(),
         replace_NAs = "with_USA"
       )

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.7.1**
+R package **mrtransport**, version **0.7.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrtransport)](https://cran.r-project.org/package=mrtransport)  [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel J, Dirnaichner A (2024). _mrtransport: Input data generation for the EDGE-Transport model_. R package version 0.7.1, <https://github.com/pik-piam/mrtransport>.
+Hoppe J, Muessel J, Dirnaichner A (2024). _mrtransport: Input data generation for the EDGE-Transport model_. R package version 0.7.2, <https://github.com/pik-piam/mrtransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrtransport: Input data generation for the EDGE-Transport model},
   author = {Johanna Hoppe and Jarusch Muessel and Alois Dirnaichner},
   year = {2024},
-  note = {R package version 0.7.1},
+  note = {R package version 0.7.2},
   url = {https://github.com/pik-piam/mrtransport},
 }
 ```


### PR DESCRIPTION
Avoid using ASCII character when converting EUR to USD by using the latest GDPuc version