### PR TITLE
delete empty line in DESCRIPTION file

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1439208'
+ValidationKey: '1459197'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.7.2
+version: 0.7.3
 date-released: '2024-09-23'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.7.2
+Version: 0.7.3
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -27,4 +27,3 @@ Imports:
     quitte,
     data.table
 Date: 2024-09-23
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.7.2**
+R package **mrtransport**, version **0.7.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrtransport)](https://cran.r-project.org/package=mrtransport)  [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel J, Dirnaichner A (2024). _mrtransport: Input data generation for the EDGE-Transport model_. R package version 0.7.2, <https://github.com/pik-piam/mrtransport>.
+Hoppe J, Muessel J, Dirnaichner A (2024). _mrtransport: Input data generation for the EDGE-Transport model_. R package version 0.7.3, <https://github.com/pik-piam/mrtransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrtransport: Input data generation for the EDGE-Transport model},
   author = {Johanna Hoppe and Jarusch Muessel and Alois Dirnaichner},
   year = {2024},
-  note = {R package version 0.7.2},
+  note = {R package version 0.7.3},
   url = {https://github.com/pik-piam/mrtransport},
 }
 ```


### PR DESCRIPTION
the empy line causes a crash in scripts trying to distribute the package on the RSE server