### PR TITLE
Change VOT to MER

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1501125'
+ValidationKey: '1521292'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.7.5
-date-released: '2024-10-19'
+version: 0.7.6
+date-released: '2024-10-21'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.7.5
+Version: 0.7.6
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -26,4 +26,4 @@ Imports:
     magrittr,
     quitte,
     data.table
-Date: 2024-10-19
+Date: 2024-10-21

--- a/R/calcEdgeTransportSAinputs.R
+++ b/R/calcEdgeTransportSAinputs.R
@@ -776,7 +776,7 @@ calcEdgeTransportSAinputs <- function(subtype, SSPscen = "SSP2EU", IEAharm = TRU
                                          valcol = "multiplier")[, c("variable", "unit") := NULL]
       setkey(valueOfTimeMultiplier, region, period, univocalName, technology)
 
-      GDPpcMERmag <- calcOutput("GDPpc", aggregate = FALSE) |> time_interpolate(highResYears)
+      GDPpcMERmag <- calcOutput("GDPpc", aggregate = FALSE, unit = "constant 2017 US$MER") |> time_interpolate(highResYears)
       GDPpcMERmag <- GDPpcMERmag[, , paste0("gdppc_", SSPscen)]
 
       GDPpcMER <- magpie2dt(GDPpcMERmag, yearcol = "period", regioncol = "region", valcol = "gdppc")[, variable := NULL]

--- a/R/toolAdjustAnnualMileage.R
+++ b/R/toolAdjustAnnualMileage.R
@@ -49,7 +49,7 @@ toolAdjustAnnualMileage <- function(dt, completeData, filter, ariadneAdjustments
   # If there are still NAs take mean over regions by technology
   dt[, value := ifelse(is.na(value), mean(value, na.rm = TRUE), value),
      by = c("period", "technology", "univocalName")]
-
+browser()
 #b) Annual Mileage for Trucks is missing completely - insert assumptions made by Alois in 2022 (probably from ARIADNE)
   annualMileageTrucks <- fread(
     text = "univocalName, annualMileage

--- a/R/toolAdjustAnnualMileage.R
+++ b/R/toolAdjustAnnualMileage.R
@@ -49,7 +49,7 @@ toolAdjustAnnualMileage <- function(dt, completeData, filter, ariadneAdjustments
   # If there are still NAs take mean over regions by technology
   dt[, value := ifelse(is.na(value), mean(value, na.rm = TRUE), value),
      by = c("period", "technology", "univocalName")]
-browser()
+
 #b) Annual Mileage for Trucks is missing completely - insert assumptions made by Alois in 2022 (probably from ARIADNE)
   annualMileageTrucks <- fread(
     text = "univocalName, annualMileage

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.7.5**
+R package **mrtransport**, version **0.7.6**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrtransport)](https://cran.r-project.org/package=mrtransport)  [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel J, Dirnaichner A (2024). _mrtransport: Input data generation for the EDGE-Transport model_. R package version 0.7.5, <https://github.com/pik-piam/mrtransport>.
+Hoppe J, Muessel J, Dirnaichner A (2024). _mrtransport: Input data generation for the EDGE-Transport model_. R package version 0.7.6, <https://github.com/pik-piam/mrtransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrtransport: Input data generation for the EDGE-Transport model},
   author = {Johanna Hoppe and Jarusch Muessel and Alois Dirnaichner},
   year = {2024},
-  note = {R package version 0.7.5},
+  note = {R package version 0.7.6},
   url = {https://github.com/pik-piam/mrtransport},
 }
 ```


### PR DESCRIPTION
The value of time was calculated using the GDPpc on PPP basis whereas all other cost components were converted on MER basis.
That led to a change in the logit cost structure favoring faster modes like aviation. 

With this PR the value of time is again calculated on MER basis.