### PR TITLE
smooth annual mileage < 2010

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2047752'
+ValidationKey: '2071330'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.10.2
-date-released: '2024-12-19'
+version: 0.10.3
+date-released: '2025-01-22'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.
 authors:
@@ -14,6 +14,11 @@ authors:
 - family-names: Muessel
   given-names: Jarusch
   email: jarusch.muessel@pik-potsdam.de
+  orcid: https://orcid.org/0000-0002-1857-7866
+- family-names: Hagen
+  given-names: Alex K.
+  email: alex.hagen@pik-potsdam.de
+  orcid: https://orcid.org/0000-0003-4793-8664
 - family-names: Dirnaichner
   given-names: Alois
 license: LGPL-3.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.10.2
+Version: 0.10.3
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -35,4 +35,4 @@ Imports:
     tidyselect,
     utils,
     zoo
-Date: 2024-12-19
+Date: 2025-01-22

--- a/R/toolAdjustAnnualMileage.R
+++ b/R/toolAdjustAnnualMileage.R
@@ -76,5 +76,9 @@ toolAdjustAnnualMileage <- function(dt, completeData, filter, ariadneAdjustments
   dt <- merge.data.table(dt, missingAnnualMileageData, by = "univocalName", all.x = TRUE, allow.cartesian = TRUE)
   dt[, value := ifelse(!is.na(annualMileage), annualMileage, value)][, annualMileage := NULL]
 
+#3 data until 2010 has weird spikes -> take 1990 value and interpolate
+  xdata <- unique(dt$period)
+  dt <- dt[period == 1990 | period > 2010]
+  dt <- rmndt::approx_dt(dt, xdata, "period", "value")
 return(dt)
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.10.2**
+R package **mrtransport**, version **0.10.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrtransport)](https://cran.r-project.org/package=mrtransport) [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,17 +39,15 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel J, Dirnaichner A (2024). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.10.2, <https://github.com/pik-piam/mrtransport>.
+Hoppe J, Muessel J, Hagen A, Dirnaichner A (2025). "mrtransport: Input data generation for the EDGE-Transport model - Version 0.10.3."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {mrtransport: Input data generation for the EDGE-Transport model},
-  author = {Johanna Hoppe and Jarusch Muessel and Alois Dirnaichner},
-  date = {2024-12-19},
-  year = {2024},
-  url = {https://github.com/pik-piam/mrtransport},
-  note = {Version: 0.10.2},
+  title = {mrtransport: Input data generation for the EDGE-Transport model - Version 0.10.3},
+  author = {Johanna Hoppe and Jarusch Muessel and Alex K. Hagen and Alois Dirnaichner},
+  date = {2025-01-22},
+  year = {2025},
 }
 ```


### PR DESCRIPTION
## Purpose of this PR
Remove spikes in transport annual mileage input data before 2010. 
As this data is not used in any projects, I think there is no extra testing needed


## Checklist:

- [ ] I used ./test-standard-runs to compare and archive the changes introduced by this PR in /p/projects/edget/PRchangeLog/

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

