### PR TITLE
Add IND scenarios and adjust the calcOutput calls accordingly 

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2133250'
+ValidationKey: '2214300'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.10.6
-date-released: '2025-02-06'
+version: 0.11.0
+date-released: '2025-02-11'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.10.6
+Version: 0.11.0
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -34,4 +34,4 @@ Imports:
     tidyselect,
     utils,
     zoo
-Date: 2025-02-06
+Date: 2025-02-11

--- a/R/calcEdgeTransportSAinputs.R
+++ b/R/calcEdgeTransportSAinputs.R
@@ -109,7 +109,7 @@ calcEdgeTransportSAinputs <- function(subtype, SSPscen = "SSP2", IEAharm = TRUE)
       unit <- "MJ/vehkm"
       description <- "Energy intensity on technology level. Sources: TRACCS, PSI, UCD, GCAM"
       weight <- calcOutput("GDP",
-                           scenario = c("SSPs", "SDPs"),
+                           scenario = c("SSPs", "SDPs", "SSP2IndiaDEAs"),
                            naming = "scenario",
                            average2020 = FALSE,
                            aggregate = FALSE) |>
@@ -177,7 +177,7 @@ calcEdgeTransportSAinputs <- function(subtype, SSPscen = "SSP2", IEAharm = TRUE)
       unit <- "vehkm/veh yr"
       description <- "Annual mileage on technology level. Sources: TRACCS, UCD"
       weight <- calcOutput("GDP",
-                           scenario = c("SSPs", "SDPs"),
+                           scenario = c("SSPs", "SDPs", "SSP2IndiaDEAs"),
                            naming = "scenario",
                            average2020 = FALSE,
                            aggregate = FALSE) |>
@@ -302,7 +302,7 @@ calcEdgeTransportSAinputs <- function(subtype, SSPscen = "SSP2", IEAharm = TRUE)
       description <- "Load factor on technology level that states the tons/number of passengers in a vehicle.
                       Sources: TRACCS, GCAM"
       weight <- calcOutput("GDP",
-                           scenario = c("SSPs", "SDPs"),
+                           scenario = c("SSPs", "SDPs", "SSP2IndiaDEAs"),
                            naming = "scenario",
                            average2020 = FALSE,
                            aggregate = FALSE) |>
@@ -363,7 +363,7 @@ calcEdgeTransportSAinputs <- function(subtype, SSPscen = "SSP2", IEAharm = TRUE)
       description <- "CAPEX for vehicle types that feature fleet tracking (cars, trucks and busses).
                       Sources: UCD, PSI"
       weight <- calcOutput("GDP",
-                           scenario = c("SSPs", "SDPs"),
+                           scenario = c("SSPs", "SDPs", "SSP2IndiaDEAs"),
                            naming = "scenario",
                            average2020 = FALSE,
                            aggregate = FALSE) |>
@@ -408,7 +408,7 @@ calcEdgeTransportSAinputs <- function(subtype, SSPscen = "SSP2", IEAharm = TRUE)
       CAPEXraw <- rbind(PSIpurchaseCosts, CAPEXUCD4W, CAPEXcombinedUCD, data$operatingSubsidyUCD)
 
       GDPpcMERmag <- calcOutput("GDPpc",
-                                scenario = c("SSPs", "SDPs"),
+                                scenario = c("SSPs", "SDPs", "SSP2IndiaDEAs"),
                                 naming = "scenario",
                                 aggregate = FALSE,
                                 unit = mrdrivers::toolGetUnitDollar()) |>
@@ -455,7 +455,7 @@ calcEdgeTransportSAinputs <- function(subtype, SSPscen = "SSP2", IEAharm = TRUE)
       description <- "Non-fuel OPEX on technology level for vehicle types that feature fleet tracking
                      (cars, trucks, busses). Sources: UCD, PSI"
       weight <- calcOutput("GDP",
-                           scenario = c("SSPs", "SDPs"),
+                           scenario = c("SSPs", "SDPs", "SSP2IndiaDEAs"),
                            naming = "scenario",
                            average2020 = FALSE,
                            aggregate = FALSE) |>
@@ -521,7 +521,7 @@ calcEdgeTransportSAinputs <- function(subtype, SSPscen = "SSP2", IEAharm = TRUE)
       description <- "CAPEX (purchase costs) for vehicle types that do not feature fleet tracking
                       (all other than cars, trucks and busses). Sources: UCD"
       weight <- calcOutput("GDP",
-                           scenario = c("SSPs", "SDPs"),
+                           scenario = c("SSPs", "SDPs", "SSP2IndiaDEAs"),
                            naming = "scenario",
                            average2020 = FALSE,
                            aggregate = FALSE) |>
@@ -574,7 +574,7 @@ calcEdgeTransportSAinputs <- function(subtype, SSPscen = "SSP2", IEAharm = TRUE)
       CAPEXraw <- rbind(CAPEXUCD, data$CAPEXcombinedUCD, data$operatingSubsidyUCD)
 
       GDPpcMERmag <- calcOutput("GDPpc",
-                                scenario = c("SSPs", "SDPs"),
+                                scenario = c("SSPs", "SDPs", "SSP2IndiaDEAs"),
                                 naming = "scenario",
                                 aggregate = FALSE,
                                 unit = mrdrivers::toolGetUnitDollar()) |>
@@ -628,7 +628,7 @@ calcEdgeTransportSAinputs <- function(subtype, SSPscen = "SSP2", IEAharm = TRUE)
       description <- "Non fuel OPEX on technology level for vehicle types that do not feature fleet tracking
                      (other than cars, trucks, busses). Sources: UCD, PSI"
       weight <- calcOutput("GDP",
-                           scenario = c("SSPs", "SDPs"),
+                           scenario = c("SSPs", "SDPs", "SSP2IndiaDEAs"),
                            naming = "scenario",
                            average2020 = FALSE,
                            aggregate = FALSE) |>
@@ -717,7 +717,7 @@ calcEdgeTransportSAinputs <- function(subtype, SSPscen = "SSP2", IEAharm = TRUE)
                       the motorized modes. Used to calculate the time value costs for passenger transport modes.
                       Sources: GCAM"
       weight <- calcOutput("GDP",
-                           scenario = c("SSPs", "SDPs"),
+                           scenario = c("SSPs", "SDPs", "SSP2IndiaDEAs"),
                            naming = "scenario",
                            average2020 = FALSE,
                            aggregate = FALSE) |>
@@ -776,7 +776,7 @@ calcEdgeTransportSAinputs <- function(subtype, SSPscen = "SSP2", IEAharm = TRUE)
                       Used to calculate the time value costs for passenger
                       transport modes. Sources: GCAM"
       weight <- calcOutput("GDP",
-                           scenario = c("SSPs", "SDPs"),
+                           scenario = c("SSPs", "SDPs", "SSP2IndiaDEAs"),
                            naming = "scenario",
                            average2020 = FALSE,
                            aggregate = FALSE) |>
@@ -825,7 +825,7 @@ calcEdgeTransportSAinputs <- function(subtype, SSPscen = "SSP2", IEAharm = TRUE)
       description <- "Time value costs for passenger transport modes.
                       Sources: GCAM"
       weight <- calcOutput("GDP",
-                           scenario = c("SSPs", "SDPs"),
+                           scenario = c("SSPs", "SDPs", "SSP2IndiaDEAs"),
                            naming = "scenario",
                            average2020 = FALSE,
                            aggregate = FALSE) |>
@@ -845,7 +845,7 @@ calcEdgeTransportSAinputs <- function(subtype, SSPscen = "SSP2", IEAharm = TRUE)
       setkey(valueOfTimeMultiplier, region, period, univocalName, technology)
 
       GDPpcMERmag <- calcOutput("GDPpc",
-                                scenario = c("SSPs", "SDPs"),
+                                scenario = c("SSPs", "SDPs", "SSP2IndiaDEAs"),
                                 naming = "scenario",
                                 aggregate = FALSE,
                                 unit = mrdrivers::toolGetUnitDollar()) |>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.10.6**
+R package **mrtransport**, version **0.11.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrtransport)](https://cran.r-project.org/package=mrtransport) [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,17 +39,15 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel J, Hagen A, Dirnaichner A (2025). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.10.6, <https://github.com/pik-piam/mrtransport>.
+Hoppe J, Muessel J, Hagen A, Dirnaichner A (2025). "mrtransport: Input data generation for the EDGE-Transport model - Version 0.11.0."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {mrtransport: Input data generation for the EDGE-Transport model},
+  title = {mrtransport: Input data generation for the EDGE-Transport model - Version 0.11.0},
   author = {Johanna Hoppe and Jarusch Muessel and Alex K. Hagen and Alois Dirnaichner},
-  date = {2025-02-06},
+  date = {2025-02-11},
   year = {2025},
-  url = {https://github.com/pik-piam/mrtransport},
-  note = {Version: 0.10.6},
 }
 ```


### PR DESCRIPTION
## Purpose of this PR

## Checklist:

- [x] I used ./test-standard-runs to compare and archive the changes introduced by this PR in /p/projects/edget/PRchangeLog/

## Further information (optional):
this PR corresponds to [this ](https://github.com/pik-piam/edgeTransport/pull/320) edegT PR

* Test runs are here: 
/p/projects/edget/PRchangeLog/20250212_INDscenarios


* Comparison of results (what changes by this PR?): 
I added the high and medium IND scenario in edgeT based on SSP2 SW values. In mrtransport I updated the GDP and Population calcOutput calls
