### PR TITLE
AM fix

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2257248'
+ValidationKey: '2277402'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.11.2
+version: 0.11.3
 date-released: '2025-03-07'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.11.2
+Version: 0.11.3
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),

--- a/R/toolAdjustAnnualMileage.R
+++ b/R/toolAdjustAnnualMileage.R
@@ -44,6 +44,20 @@ toolAdjustAnnualMileage <- function(dt, completeData, filter, ariadneAdjustments
      by = c("period", "technology", "univocalName")]
   dt <- dt[period <= 2010, value := value[period == 2010], by = .(region, univocalName, variable, technology)]
 
+<<<<<<< Updated upstream
+=======
+  #adjust outliers for scenarioMIP validation
+  ISOcountriesMap <- system.file("extdata", "regionmappingISOto21to12.csv", package = "mrtransport", mustWork = TRUE)
+  ISOcountriesMap <- fread(ISOcountriesMap, skip = 0)
+  dt[, mean_value := mean(value, na.rm = TRUE), by = c("univocalName", "technology", "period")]
+  dt[region %in% ISOcountriesMap[regionCode21 == "CHA"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W,
+     value := mean_value]
+  dt[region %in% ISOcountriesMap[regionCode21 %in% c("EWN", "ENC", "UKI", "NES")]$countryCode &
+       grepl("Bus", univocalName), value := mean_value]
+
+  dt[, mean_value := NULL]
+
+>>>>>>> Stashed changes
   # b) Annual Mileage for Trucks is missing completely - insert assumptions made by Alois in 2022
   # (probably from ARIADNE)
   annualMileageTrucks <- fread(
@@ -74,5 +88,9 @@ toolAdjustAnnualMileage <- function(dt, completeData, filter, ariadneAdjustments
   xdata <- unique(dt$period)
   dt <- dt[period == 1990 | period > 2010]
   dt <- rmndt::approx_dt(dt, xdata, "period", "value")
+
+  #In the scenarioMIP validation we decided to only use constant annual mileage values until we have better data.
+  dt <- dt[, value := value[period == 2030], by = setdiff(names(dt), c("value", "period"))]
+
   return(dt)
 }

--- a/R/toolAdjustAnnualMileage.R
+++ b/R/toolAdjustAnnualMileage.R
@@ -44,8 +44,7 @@ toolAdjustAnnualMileage <- function(dt, completeData, filter, ariadneAdjustments
      by = c("period", "technology", "univocalName")]
   dt <- dt[period <= 2010, value := value[period == 2010], by = .(region, univocalName, variable, technology)]
 
-<<<<<<< Updated upstream
-=======
+
   #adjust outliers for scenarioMIP validation
   ISOcountriesMap <- system.file("extdata", "regionmappingISOto21to12.csv", package = "mrtransport", mustWork = TRUE)
   ISOcountriesMap <- fread(ISOcountriesMap, skip = 0)
@@ -57,7 +56,6 @@ toolAdjustAnnualMileage <- function(dt, completeData, filter, ariadneAdjustments
 
   dt[, mean_value := NULL]
 
->>>>>>> Stashed changes
   # b) Annual Mileage for Trucks is missing completely - insert assumptions made by Alois in 2022
   # (probably from ARIADNE)
   annualMileageTrucks <- fread(

--- a/R/toolAdjustAnnualMileage.R
+++ b/R/toolAdjustAnnualMileage.R
@@ -49,7 +49,7 @@ toolAdjustAnnualMileage <- function(dt, completeData, filter, ariadneAdjustments
   ISOcountriesMap <- system.file("extdata", "regionmappingISOto21to12.csv", package = "mrtransport", mustWork = TRUE)
   ISOcountriesMap <- fread(ISOcountriesMap, skip = 0)
   dt[, mean_value := mean(value, na.rm = TRUE), by = c("univocalName", "technology", "period")]
-  dt[region %in% ISOcountriesMap[regionCode21 == "CHA"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W,
+  dt[region %in% ISOcountriesMap[regionCode21 %in% c("NES", "CHA")]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W,
      value := mean_value]
   dt[region %in% ISOcountriesMap[regionCode21 %in% c("EWN", "ENC", "UKI", "NES")]$countryCode &
        grepl("Bus", univocalName), value := mean_value]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.11.2**
+R package **mrtransport**, version **0.11.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrtransport)](https://cran.r-project.org/package=mrtransport) [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,13 +39,13 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel J, Hagen A, Dirnaichner A (2025). "mrtransport: Input data generation for the EDGE-Transport model - Version 0.11.2."
+Hoppe J, Muessel J, Hagen A, Dirnaichner A (2025). "mrtransport: Input data generation for the EDGE-Transport model - Version 0.11.3."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {mrtransport: Input data generation for the EDGE-Transport model - Version 0.11.2},
+  title = {mrtransport: Input data generation for the EDGE-Transport model - Version 0.11.3},
   author = {Johanna Hoppe and Jarusch Muessel and Alex K. Hagen and Alois Dirnaichner},
   date = {2025-03-07},
   year = {2025},


### PR DESCRIPTION
## Purpose of this PR
Adjust outliers in annual mileage for the scenariosMIP validation. 

Other input PRs are here 
[AM](https://github.com/pik-piam/mrtransport/pull/38/files)
[LF](https://github.com/pik-piam/mrtransport/pull/39/files)
[EnInt](https://github.com/pik-piam/mrtransport/pull/40/files)

## Checklist:

- [x] I used ./test-standard-runs to compare and archive the changes introduced by this PR in /p/projects/edget/PRchangeLog/

## Further information (optional):

* Test runs are here: 
```/p/projects/edget/PRchangeLog/20250228_annualMileage```

* Comparison of results (what changes by this PR?): 
I compared the changes with my last changes of the input parameters in ```/p/projects/edget/PRchangeLog/20250218_inputFixes```


