### PR TITLE
adjust enInt and leave out BEVs in IEAharmonization

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2236650'
+ValidationKey: '2257248'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.11.1
-date-released: '2025-03-03'
+version: 0.11.2
+date-released: '2025-03-07'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.11.1
+Version: 0.11.2
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -34,4 +34,4 @@ Imports:
     tidyselect,
     utils,
     zoo
-Date: 2025-03-03
+Date: 2025-03-07

--- a/R/toolAdjustEnergyIntensity.R
+++ b/R/toolAdjustEnergyIntensity.R
@@ -129,13 +129,13 @@ toolAdjustEnergyIntensity <- function(dt, regionTRACCS, TrendsEnIntPSI, filter, 
   missingPassRailDataIDN[, region := "IDN"]
   dt <- rbind(dt, missingPassRailDataIDN)
 
-  # 4: adjustments for scenarioMIP validation: adjust outliers to global mean 
+  # 4: adjustments for scenarioMIP validation: adjust outliers to global mean
   ISOcountriesMap <- system.file("extdata", "regionmappingISOto21to12.csv", package = "mrtransport", mustWork = TRUE)
   ISOcountriesMap <- fread(ISOcountriesMap, skip = 0)
   dt[, meanValue := mean(value, na.rm = TRUE), by = c("univocalName", "technology", "period")]
   dt[region %in% ISOcountriesMap[regionCode21 == "LAM"]$countryCode & univocalName %in% c("Compact Car") &
-     technology == "Gases", value := meanValue]
-     
+       technology == "Gases", value := meanValue]
+
   dt[, meanValue := NULL]
 
   return(dt)

--- a/R/toolAdjustEnergyIntensity.R
+++ b/R/toolAdjustEnergyIntensity.R
@@ -16,7 +16,7 @@
 
 toolAdjustEnergyIntensity <- function(dt, regionTRACCS, TrendsEnIntPSI, filter, ariadneAdjustments = TRUE) {
   region <- technology <- period <- value  <- region   <- TRACCS <-
-    enIntLargeCarSUV <- univocalName <- NULL
+    enIntLargeCarSUV <- univocalName <- meanValue <- regionCode21 <- NULL
 
   # To complete dataset and ensure consistency and actuality a number of fixes are applied on the raw source data
   # 1: PSI trends in energyitensity are applied to TRACCS car and trucks data [TRACCS data only available until 2010]
@@ -129,15 +129,14 @@ toolAdjustEnergyIntensity <- function(dt, regionTRACCS, TrendsEnIntPSI, filter, 
   missingPassRailDataIDN[, region := "IDN"]
   dt <- rbind(dt, missingPassRailDataIDN)
 
-  
   # 4: adjustments for scenarioMIP validation: adjust outliers to global mean 
   ISOcountriesMap <- system.file("extdata", "regionmappingISOto21to12.csv", package = "mrtransport", mustWork = TRUE)
   ISOcountriesMap <- fread(ISOcountriesMap, skip = 0)
-  dt[, mean_value := mean(value, na.rm = TRUE), by = c("univocalName", "technology", "period")]
-  dt[region %in% ISOcountriesMap[regionCode21 == "LAM"]$countryCode & univocalName %in% c("Compact Car")&
-     technology == "Gases", value := mean_value]
+  dt[, meanValue := mean(value, na.rm = TRUE), by = c("univocalName", "technology", "period")]
+  dt[region %in% ISOcountriesMap[regionCode21 == "LAM"]$countryCode & univocalName %in% c("Compact Car") &
+     technology == "Gases", value := meanValue]
      
-  dt[, mean_value := NULL]
+  dt[, meanValue := NULL]
 
   return(dt)
 }

--- a/R/toolAdjustEnergyIntensity.R
+++ b/R/toolAdjustEnergyIntensity.R
@@ -109,18 +109,6 @@ toolAdjustEnergyIntensity <- function(dt, regionTRACCS, TrendsEnIntPSI, filter, 
   dt4W[is.na(value) & univocalName == "Large Car", value := enIntLargeCarSUV * 0.9][, enIntLargeCarSUV := NULL]
   dt <- rbind(dt[!univocalName %in% filter$trn_pass_road_LDV_4W], dt4W)
 
-  #adjust outliers for scenarioMIP validation
-  ISOcountriesMap <- system.file("extdata", "regionmappingISOto21to12.csv", package = "mrtransport", mustWork = TRUE)
-  ISOcountriesMap <- fread(ISOcountriesMap, skip = 0)
-  dt[, mean_value := mean(value, na.rm = TRUE), by = c("univocalName", "technology", "period")]
-  dt[region %in% ISOcountriesMap[regionCode21 == "LAM"]$countryCode & univocalName %in% c("Compact Car")&
-     technology == "Gases", value := mean_value]
-  #dt[region %in% ISOcountriesMap[regionCode21 %in% c("CAZ", "LAM")]$countryCode & univocalName %in% c("Mini Car") &
-  #     technology == "BEV", value := mean_value]
-
-  dt[, mean_value := NULL]
-
-
   # e) Some non TRACCS countries ("ARE" "BHR" "IRN" "IRQ" "ISR" "JOR" "KWT" "LBN" "OMN" "PSE" "QAT" "SAU" "SYR" "YEM")
   # are missing data for Freight and Passenger Rail running on liquids. Average of other non TRACCS countries
   # is taken
@@ -140,6 +128,16 @@ toolAdjustEnergyIntensity <- function(dt, regionTRACCS, TrendsEnIntPSI, filter, 
   missingPassRailDataIDN <- dt[region %in% c("MYS") & univocalName == "Passenger Rail" & technology == "Electric"]
   missingPassRailDataIDN[, region := "IDN"]
   dt <- rbind(dt, missingPassRailDataIDN)
+
+  
+  # 4: adjustments for scenarioMIP validation: adjust outliers to global mean 
+  ISOcountriesMap <- system.file("extdata", "regionmappingISOto21to12.csv", package = "mrtransport", mustWork = TRUE)
+  ISOcountriesMap <- fread(ISOcountriesMap, skip = 0)
+  dt[, mean_value := mean(value, na.rm = TRUE), by = c("univocalName", "technology", "period")]
+  dt[region %in% ISOcountriesMap[regionCode21 == "LAM"]$countryCode & univocalName %in% c("Compact Car")&
+     technology == "Gases", value := mean_value]
+     
+  dt[, mean_value := NULL]
 
   return(dt)
 }

--- a/R/toolAdjustEnergyIntensity.R
+++ b/R/toolAdjustEnergyIntensity.R
@@ -109,6 +109,18 @@ toolAdjustEnergyIntensity <- function(dt, regionTRACCS, TrendsEnIntPSI, filter, 
   dt4W[is.na(value) & univocalName == "Large Car", value := enIntLargeCarSUV * 0.9][, enIntLargeCarSUV := NULL]
   dt <- rbind(dt[!univocalName %in% filter$trn_pass_road_LDV_4W], dt4W)
 
+  #adjust outliers for scenarioMIP validation
+  ISOcountriesMap <- system.file("extdata", "regionmappingISOto21to12.csv", package = "mrtransport", mustWork = TRUE)
+  ISOcountriesMap <- fread(ISOcountriesMap, skip = 0)
+  dt[, mean_value := mean(value, na.rm = TRUE), by = c("univocalName", "technology", "period")]
+  dt[region %in% ISOcountriesMap[regionCode21 == "LAM"]$countryCode & univocalName %in% c("Compact Car")&
+     technology == "Gases", value := mean_value]
+  #dt[region %in% ISOcountriesMap[regionCode21 %in% c("CAZ", "LAM")]$countryCode & univocalName %in% c("Mini Car") &
+  #     technology == "BEV", value := mean_value]
+
+  dt[, mean_value := NULL]
+
+
   # e) Some non TRACCS countries ("ARE" "BHR" "IRN" "IRQ" "ISR" "JOR" "KWT" "LBN" "OMN" "PSE" "QAT" "SAU" "SYR" "YEM")
   # are missing data for Freight and Passenger Rail running on liquids. Average of other non TRACCS countries
   # is taken

--- a/R/toolAdjustLoadFactor.R
+++ b/R/toolAdjustLoadFactor.R
@@ -11,7 +11,7 @@
 
 toolAdjustLoadFactor <- function(dt, completeData, TRACCScountries, filter) {
   period <- value <- region <- univocalName <- univocalName <- check <- unit  <- variable <-
-    mean_value <- regionCode21 <- NULL
+    meanValue <- regionCode21 <- NULL
 
   #1: Correct unrealisitc data
   #a) 3_5t load factor as provided by GCAM is unrealistically high
@@ -42,10 +42,10 @@ toolAdjustLoadFactor <- function(dt, completeData, TRACCScountries, filter) {
   # 3: adjustments for scenarioMIP validation adjust outliers to global mean 
   ISOcountriesMap <- system.file("extdata", "regionmappingISOto21to12.csv", package = "mrtransport", mustWork = TRUE)
   ISOcountriesMap <- fread(ISOcountriesMap, skip = 0)
-  dt[, mean_value := mean(value, na.rm = TRUE), by = c("univocalName", "technology", "period")]
+  dt[, meanValue := mean(value, na.rm = TRUE), by = c("univocalName", "technology", "period")]
   dt[region %in% ISOcountriesMap[regionCode21 == "CAZ"]$countryCode & univocalName %in% c("Truck (7_5t)"),
-     value := mean_value]
-  dt[, mean_value := NULL]
+     value := meanValue]
+  dt[, meanValue := NULL]
 
   return(dt)
 }

--- a/R/toolAdjustLoadFactor.R
+++ b/R/toolAdjustLoadFactor.R
@@ -34,12 +34,13 @@ toolAdjustLoadFactor <- function(dt, completeData, TRACCScountries, filter) {
   dt[is.na(unit), unit := ifelse(univocalName %in% filter$trn_pass, "p/veh", "t/veh")]
   dt[is.na(variable), variable := "Load factor"]
 
-  # data until 2010 has weird spikes for some regions -> remove data between 1991 and 2009 and interpolate afterward to remove the spikes
+  # data until 2010 has weird spikes for some regions
+  # -> remove data between 1991 and 2009 and interpolate afterward to remove the spikes
   xdata <- unique(dt$period)
   dt <- dt[period == 1990 | period > 2010]
   dt <- rmndt::approx_dt(dt, xdata, "period", "value")
 
-  # 3: adjustments for scenarioMIP validation adjust outliers to global mean 
+  # 3: adjustments for scenarioMIP validation adjust outliers to global mean
   ISOcountriesMap <- system.file("extdata", "regionmappingISOto21to12.csv", package = "mrtransport", mustWork = TRUE)
   ISOcountriesMap <- fread(ISOcountriesMap, skip = 0)
   dt[, meanValue := mean(value, na.rm = TRUE), by = c("univocalName", "technology", "period")]

--- a/R/toolIEAharmonization.R
+++ b/R/toolIEAharmonization.R
@@ -93,10 +93,12 @@ toolIEAharmonization <- function(...) {
     check[, check := sum(check), by = c("region", "isBunk", "te", "period")][, diff := abs(check - feIEA)]
 
     #There are no electric vehicles on the road before 2010. Hence, ES demand is zero and the intensity was set to zero.
-    #To avoid having efficiencies near zero in the input data, we reversed the harmonization for such electric road vehicles.
+    #To avoid having efficiencies near zero in the input data,
+    #we reversed the harmonization for such electric road vehicles.
     #We left the 2005 value because this year is relevant for the REMIND calibration
-    groupingColumns <- setdiff(names(enIntensity), c("feIEA", "harmFactor", "value" ))
-    enIntensity[technology %in% c("BEV", "Hybrid electric") & period > 2005, value:= value/harmFactor, by = groupingColumns]
+    groupingColumns <- setdiff(names(enIntensity), c("feIEA", "harmFactor", "value"))
+    enIntensity[technology %in% c("BEV", "Hybrid electric") & period > 2005,
+                value := value / harmFactor, by = groupingColumns]
     if (nrow(check[diff > 1e-2]) > 0) {
       stop("There is a problem regarding the Harmonization of the energy intensity data to match IEA energy balances
          final energy")

--- a/R/toolIEAharmonization.R
+++ b/R/toolIEAharmonization.R
@@ -11,7 +11,7 @@
 
 toolIEAharmonization <- function(...) {
   fe <- te <- period <- isBunk <- flow <- . <- feIEA <- region <- univocalName <-
-    value <- enService <- harmFactor <- check <- technology  <- NULL
+    value <- enService <- harmFactor <- check <- technology  <- groupingColumns <- NULL
 
   data <- list(...)
   harmonizationYears <- c(1990, 2005, 2010)

--- a/R/toolIEAharmonization.R
+++ b/R/toolIEAharmonization.R
@@ -92,9 +92,11 @@ toolIEAharmonization <- function(...) {
     check[, check := (value / loadFactor) * enService * bn * MJtoEJ]
     check[, check := sum(check), by = c("region", "isBunk", "te", "period")][, diff := abs(check - feIEA)]
 
-    #There are no electric vehicles on the road before 2010
-    grouping_columns <- setdiff(names(enIntensity), c("feIEA", "harmFactor", "value" ))
-    enIntensity[technology %in% c("BEV", "Hybrid electric") & period > 2005, value:= value/harmFactor, by = grouping_columns]
+    #There are no electric vehicles on the road before 2010. Hence, ES demand is zero and the intensity was set to zero.
+    #To avoid having efficiencies near zero in the input data, we reversed the harmonization for such electric road vehicles.
+    #We left the 2005 value because this year is relevant for the REMIND calibration
+    groupingColumns <- setdiff(names(enIntensity), c("feIEA", "harmFactor", "value" ))
+    enIntensity[technology %in% c("BEV", "Hybrid electric") & period > 2005, value:= value/harmFactor, by = groupingColumns]
     if (nrow(check[diff > 1e-2]) > 0) {
       stop("There is a problem regarding the Harmonization of the energy intensity data to match IEA energy balances
          final energy")

--- a/R/toolIEAharmonization.R
+++ b/R/toolIEAharmonization.R
@@ -92,6 +92,9 @@ toolIEAharmonization <- function(...) {
     check[, check := (value / loadFactor) * enService * bn * MJtoEJ]
     check[, check := sum(check), by = c("region", "isBunk", "te", "period")][, diff := abs(check - feIEA)]
 
+    #There are no electric vehicles on the road before 2010
+    grouping_columns <- setdiff(names(enIntensity), c("feIEA", "harmFactor", "value" ))
+    enIntensity[technology %in% c("BEV", "Hybrid electric") & period > 2005, value:= value/harmFactor, by = grouping_columns]
     if (nrow(check[diff > 1e-2]) > 0) {
       stop("There is a problem regarding the Harmonization of the energy intensity data to match IEA energy balances
          final energy")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.11.1**
+R package **mrtransport**, version **0.11.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrtransport)](https://cran.r-project.org/package=mrtransport) [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,15 +39,15 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel J, Hagen A, Dirnaichner A (2025). "mrtransport: Input data generation for the EDGE-Transport model - Version 0.11.1."
+Hoppe J, Muessel J, Hagen A, Dirnaichner A (2025). "mrtransport: Input data generation for the EDGE-Transport model - Version 0.11.2."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {mrtransport: Input data generation for the EDGE-Transport model - Version 0.11.1},
+  title = {mrtransport: Input data generation for the EDGE-Transport model - Version 0.11.2},
   author = {Johanna Hoppe and Jarusch Muessel and Alex K. Hagen and Alois Dirnaichner},
-  date = {2025-03-03},
+  date = {2025-03-07},
   year = {2025},
 }
 ```


### PR DESCRIPTION
## Purpose of this PR
Adjust outliers in enInt for the scenariosMIP validation. Also, take out BEVs from the IEA harmonization. One issue remains and will be dealt with next week: harmonization factors for Gases are very high

Other input PRs are here 
[AM](https://github.com/pik-piam/mrtransport/pull/38/files)
[LF](https://github.com/pik-piam/mrtransport/pull/39/files)
[EnInt](https://github.com/pik-piam/mrtransport/pull/40/files)

## Checklist:

- [ ] I used ./test-standard-runs to compare and archive the changes introduced by this PR in /p/projects/edget/PRchangeLog/


* Test runs are here: 
```/p/projects/edget/PRchangeLog/20250228_enInt```

* Comparison of results (what changes by this PR?): 
I compared the changes with my last changes of the input parameters in ```/p/projects/edget/PRchangeLog/20250218_inputFixes```

