### PR TITLE
Fix enInt before 2005

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2299836'
+ValidationKey: '2320125'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2277402'
+ValidationKey: '2299836'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -35,15 +35,6 @@ jobs:
           # gms, goxygen, GDPuc) will usually have an outdated binary version
           # available; by using extra-packages we get the newest version
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.9
-
-      - name: Install python dependencies if applicable
-        run: |
-          [ -f requirements.txt ] && python -m pip install --upgrade pip wheel || true
-          [ -f requirements.txt ] && pip install -r requirements.txt || true
-
       - name: Run pre-commit checks
         shell: bash
         run: |

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.11.3
-date-released: '2025-03-07'
+version: 0.11.4
+date-released: '2025-03-27'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.
 authors:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.11.4
-date-released: '2025-03-27'
+version: 0.11.5
+date-released: '2025-03-28'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.11.4
+Version: 0.11.5
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -34,4 +34,4 @@ Imports:
     tidyselect,
     utils,
     zoo
-Date: 2025-03-27
+Date: 2025-03-28

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.11.3
+Version: 0.11.4
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -34,4 +34,4 @@ Imports:
     tidyselect,
     utils,
     zoo
-Date: 2025-03-07
+Date: 2025-03-27

--- a/R/toolAdjustEnergyIntensity.R
+++ b/R/toolAdjustEnergyIntensity.R
@@ -138,5 +138,10 @@ toolAdjustEnergyIntensity <- function(dt, regionTRACCS, TrendsEnIntPSI, filter, 
 
   dt[, meanValue := NULL]
 
+  # 5: data until 2005 is fixed to not impact changes in lifetime in the fleet calculation (in edgeT)
+  xdata <- unique(dt$period)
+  dt <- dt[period == 1990 | period > 2005]
+  dt <- rmndt::approx_dt(dt, xdata, "period", "value")
+
   return(dt)
 }

--- a/R/toolAdjustEnergyIntensity.R
+++ b/R/toolAdjustEnergyIntensity.R
@@ -140,8 +140,8 @@ toolAdjustEnergyIntensity <- function(dt, regionTRACCS, TrendsEnIntPSI, filter, 
 
   # 5: data until 2005 is fixed to not impact changes in lifetime in the fleet calculation (in edgeT)
   xdata <- unique(dt$period)
-  dt <- dt[period == 1990 | period > 2005]
-  dt <- rmndt::approx_dt(dt, xdata, "period", "value")
+  dt <- dt[period >= 2005]
+  dt <- rmndt::approx_dt(dt, xdata, "period", "value",   extrapolate = TRUE)
 
   return(dt)
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.11.4**
+R package **mrtransport**, version **0.11.5**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrtransport)](https://cran.r-project.org/package=mrtransport) [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,15 +39,15 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel J, Hagen A, Dirnaichner A (2025). "mrtransport: Input data generation for the EDGE-Transport model - Version 0.11.4."
+Hoppe J, Muessel J, Hagen A, Dirnaichner A (2025). "mrtransport: Input data generation for the EDGE-Transport model - Version 0.11.5."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {mrtransport: Input data generation for the EDGE-Transport model - Version 0.11.4},
+  title = {mrtransport: Input data generation for the EDGE-Transport model - Version 0.11.5},
   author = {Johanna Hoppe and Jarusch Muessel and Alex K. Hagen and Alois Dirnaichner},
-  date = {2025-03-27},
+  date = {2025-03-28},
   year = {2025},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.11.3**
+R package **mrtransport**, version **0.11.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrtransport)](https://cran.r-project.org/package=mrtransport) [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,15 +39,15 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel J, Hagen A, Dirnaichner A (2025). "mrtransport: Input data generation for the EDGE-Transport model - Version 0.11.3."
+Hoppe J, Muessel J, Hagen A, Dirnaichner A (2025). "mrtransport: Input data generation for the EDGE-Transport model - Version 0.11.4."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {mrtransport: Input data generation for the EDGE-Transport model - Version 0.11.3},
+  title = {mrtransport: Input data generation for the EDGE-Transport model - Version 0.11.4},
   author = {Johanna Hoppe and Jarusch Muessel and Alex K. Hagen and Alois Dirnaichner},
-  date = {2025-03-07},
+  date = {2025-03-27},
   year = {2025},
 }
 ```


### PR DESCRIPTION
## Purpose of this PR
varying enInt before 2005 leads to changes in fleet enInt when changing a vehicles lifetime. Now I this should be fixed with excluding values before 2005  in the fleetESdemand  (see [this ](https://github.com/pik-piam/edgeTransport/pull/337) edgeT PR)and fixing enInt to before 2005

## Checklist:

- [x] I used ./test-standard-runs to compare and archive the changes introduced by this PR in /p/projects/edget/PRchangeLog/

## Further information (optional):

* Test runs are here: 
`/p/projects/edget/PRchangeLog/20250328_enIntmrTransport`


