### PR TITLE
filter transport items early on in IEA harmonization

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2440200'
+ValidationKey: '2466343'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.12.0
-date-released: '2025-09-04'
+version: 0.12.1
+date-released: '2025-10-22'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.12.0
+Version: 0.12.1
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -14,7 +14,7 @@ License: LGPL-3 | file LICENSE
 URL: https://github.com/pik-piam/mrtransport
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Depends:
     madrat (>= 3.7.1),
     mrcommons,
@@ -34,4 +34,4 @@ Imports:
     tidyselect,
     utils,
     zoo
-Date: 2025-09-04
+Date: 2025-10-22

--- a/R/calcIEAOutputTransport.R
+++ b/R/calcIEAOutputTransport.R
@@ -20,20 +20,13 @@ calcIEAOutputTransport <- function() {
   ieamatch <- toolGetMapping(type = "sectoral", name = "structuremappingIO_outputs.csv",
                              where = "mrcommons")
 
-  # add total buildings electricity demand (feelb = feelcb + feelhpb + feelrhb)
-  ieamatch <- rbind(
-    ieamatch,
-    ieamatch %>%
-      dplyr::filter(.data$REMINDitems_out %in% c("feelcb", "feelhpb", "feelrhb")) %>%
-      dplyr::mutate(REMINDitems_out = "feelb")
-  )
-
-
   target <- c("REMINDitems_in", "REMINDitems_out", "REMINDitems_tech", "iea_product", "iea_flows")
 
   ieamatch <- ieamatch %>%
     dplyr::select(tidyselect::all_of(c("iea_product", "iea_flows", "Weight", target))) %>%
     stats::na.omit() %>%
+    # select only fuel types that are represented in EDGE-T
+    dplyr::filter(.data$REMINDitems_out %in% c("fedie", "fepet", "fegat", "feelt")) %>%
     tidyr::unite("target", tidyselect::all_of(target), sep = ".", remove = FALSE) %>%
     tidyr::unite("product.flow", c("iea_product", "iea_flows"), sep = ".") %>%
     dplyr::filter(.data$product.flow %in% getNames(data))

--- a/R/toolIEAharmonization.R
+++ b/R/toolIEAharmonization.R
@@ -18,10 +18,9 @@ toolIEAharmonization <- function(...) {
 
   # Load IEA energy balances data for harmonization [unit: EJ]
   IEAbalMag <- calcOutput(type = "IEAOutputTransport", aggregate = FALSE)
+
   IEAbal <-  magpie2dt(IEAbalMag, datacols = c("se", "fe", "te", "mod", "flow"),
                        regioncol = "region", yearcol = "period")
-  # Select only fuel types that are represented in EDGE-T
-  IEAbal <- IEAbal[fe %in% c("fedie", "fepet", "fegat", "feelt")]
   IEAbal <- IEAbal[te != "dot"]  #delete fedie.dot #Q: what is fedie.dot?
   setnames(IEAbal, "value", "feIEA")
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.12.0**
+R package **mrtransport**, version **0.12.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrtransport)](https://cran.r-project.org/package=mrtransport) [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,15 +39,17 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel J, Hagen A, Dirnaichner A (2025). "mrtransport: Input data generation for the EDGE-Transport model - Version 0.12.0."
+Hoppe J, Muessel J, Hagen A, Dirnaichner A (2025). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.12.1, <https://github.com/pik-piam/mrtransport>.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {mrtransport: Input data generation for the EDGE-Transport model - Version 0.12.0},
+  title = {mrtransport: Input data generation for the EDGE-Transport model},
   author = {Johanna Hoppe and Jarusch Muessel and Alex K. Hagen and Alois Dirnaichner},
-  date = {2025-09-04},
+  date = {2025-10-22},
   year = {2025},
+  url = {https://github.com/pik-piam/mrtransport},
+  note = {Version: 0.12.1},
 }
 ```


### PR DESCRIPTION
## Purpose of this PR

This PR filters the EDGE-T items early on by reducing the mapping from IEA to EDGE items. Reduces compute time and makes it clearer which items are actually needed in EDGE-T from `structuremappingIO_outputs.csv`.
This PR is part of the task: https://github.com/remindmodel/development_issues/issues/657

## Checklist:

- [x] I used ./test-standard-runs to compare and archive the changes introduced by this PR in /p/projects/edget/PRchangeLog/

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

