### PR TITLE
update of Chinese truck sizes in historic data

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2561250'
+ValidationKey: '2581740'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2540512'
+ValidationKey: '2561250'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2581740'
+ValidationKey: '2602230'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2684714'
+ValidationKey: '2725702'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '24878502'
+ValidationKey: '2664090'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '24835092'
+ValidationKey: '24858009'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '24858009'
+ValidationKey: '24878502'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2643210'
+ValidationKey: '24794110'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2622720'
+ValidationKey: '2643210'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2602230'
+ValidationKey: '2622720'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2664090'
+ValidationKey: '2684714'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2466343'
+ValidationKey: '2540512'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '24794110'
+ValidationKey: '24835092'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.12.7
+version: 0.12.8
 date-released: '2026-02-06'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.12.10
+version: 0.12.12
 date-released: '2026-02-07'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.12.6
+version: 0.12.7
 date-released: '2026-02-06'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.13.1
+version: 0.13.3
 date-released: '2026-02-10'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.12.4
-date-released: '2026-02-04'
+version: 0.12.5
+date-released: '2026-02-06'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.
 authors:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.12.5
+version: 0.12.6
 date-released: '2026-02-06'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.12.9
-date-released: '2026-02-06'
+version: 0.12.10
+date-released: '2026-02-07'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.
 authors:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.12.13
+version: 0.12.14
 date-released: '2026-02-09'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.12.1
-date-released: '2025-10-22'
+version: 0.12.4
+date-released: '2026-02-04'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.
 authors:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.12.8
+version: 0.12.9
 date-released: '2026-02-06'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.12.12
-date-released: '2026-02-07'
+version: 0.12.13
+date-released: '2026-02-09'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.
 authors:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.13.0
-date-released: '2026-02-09'
+version: 0.13.1
+date-released: '2026-02-10'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.
 authors:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.12.14
+version: 0.13.0
 date-released: '2026-02-09'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.12.4
+Version: 0.12.5
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -34,4 +34,4 @@ Imports:
     tidyselect,
     utils,
     zoo
-Date: 2026-02-04
+Date: 2026-02-06

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.12.9
+Version: 0.12.10
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -34,4 +34,4 @@ Imports:
     tidyselect,
     utils,
     zoo
-Date: 2026-02-06
+Date: 2026-02-07

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.12.6
+Version: 0.12.7
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.12.13
+Version: 0.12.14
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.12.5
+Version: 0.12.6
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.12.1
+Version: 0.12.4
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -34,4 +34,4 @@ Imports:
     tidyselect,
     utils,
     zoo
-Date: 2025-10-22
+Date: 2026-02-04

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.12.10
+Version: 0.12.12
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.12.8
+Version: 0.12.9
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.12.12
+Version: 0.12.13
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -34,4 +34,4 @@ Imports:
     tidyselect,
     utils,
     zoo
-Date: 2026-02-07
+Date: 2026-02-09

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.13.0
+Version: 0.13.1
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -34,4 +34,4 @@ Imports:
     tidyselect,
     utils,
     zoo
-Date: 2026-02-09
+Date: 2026-02-10

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.12.7
+Version: 0.12.8
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.12.14
+Version: 0.13.0
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.13.1
+Version: 0.13.3
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),

--- a/R/calcEdgeTransportSAinputs.R
+++ b/R/calcEdgeTransportSAinputs.R
@@ -247,13 +247,16 @@ calcEdgeTransportSAinputs <- function(subtype, SSPscen = "SSP2", IEAharm = TRUE)
                                           IEAharm = FALSE, warnNA = FALSE, aggregate = FALSE))
       loadFactor <- magpie2dt(calcOutput(type = "EdgeTransportSAinputs", subtype = "loadFactor",
                                          warnNA = FALSE, aggregate = FALSE))
+      annualMileage <- magpie2dt(calcOutput(type = "EdgeTransportSAinputs", subtype = "annualMileage",
+                                         warnNA = FALSE, aggregate = FALSE))
 
       # Inter- and extrapolate all data to model input data years
       data <- list(esDemandGCAM     = esDemandGCAM,
                    esDemandTRACCS   = esDemandTRACCS,
                    feDemandEurostat = feDemandEurostat,
                    enIntensity      = enIntensity,
-                   loadFactor       = loadFactor)
+                   loadFactor       = loadFactor,
+                   annualMileage    = annualMileage)
 
       # The historical energy service demand is only used for years <= 2010, future years will be calculated by demand
       # regression in the model
@@ -263,7 +266,7 @@ calcEdgeTransportSAinputs <- function(subtype, SSPscen = "SSP2", IEAharm = TRUE)
 
       esDemandRaw <- toolMergeHistESdemand(data, filterEntries, countriesTRACCS)
 
-      esDemand <- toolAdjustEsDemand(esDemandRaw, ISOcountriesMap, completeDataSet, filterEntries)
+      esDemand <- toolAdjustEsDemand(esDemandRaw, ISOcountriesMap, completeDataSet, filterEntries, data)
 
       # Harmonize energy intensity data in order to match IEA final energy values
       if (IEAharm == TRUE) {

--- a/R/toolAdjustEsDemand.R
+++ b/R/toolAdjustEsDemand.R
@@ -69,7 +69,7 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
                                     region = c(rep("CHN",5),rep("JPN",5)),
                                     variable = "Share_in_Vehicles",
                                     unit = "Percent",
-                                    value = c( c(76, 5, 3, 3, 13), c(85,3,2,1,9)))
+                                    value = c( c(76, 5, 3, 3, 13), c(88,1,1,1,9)))
 
 
 
@@ -219,12 +219,12 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
 
   carTypes <- c("Compact Car", "Large Car", "Large Car and SUV", "Midsize Car", "Mini Car", "Subcompact Car","Van")
 
-  dt[univocalName %in% carTypes & region == "CHN" & period == 2010, value := 3 * value]
-  dt[univocalName %in% carTypes & region == "CHN" & period == 2009, value := 2.8 * value]
-  dt[univocalName %in% carTypes & region == "CHN" & period == 2008, value := 2.6 * value]
-  dt[univocalName %in% carTypes & region == "CHN" & period == 2007, value := 2.4 * value]
-  dt[univocalName %in% carTypes & region == "CHN" & period == 2006, value := 2.2 * value]
-  dt[univocalName %in% carTypes & region == "CHN" & period <= 2005, value := 2   * value]
+  dt[univocalName %in% carTypes & region == "CHN" & period == 2010, value := 2.5 * value]
+  dt[univocalName %in% carTypes & region == "CHN" & period == 2009, value := 2.3 * value]
+  dt[univocalName %in% carTypes & region == "CHN" & period == 2008, value := 2.1 * value]
+  dt[univocalName %in% carTypes & region == "CHN" & period == 2007, value := 1.9 * value]
+  dt[univocalName %in% carTypes & region == "CHN" & period == 2006, value := 1.7 * value]
+  dt[univocalName %in% carTypes & region == "CHN" & period <= 2005, value := 1.5   * value]
 
   ############ end of new CHA stuff from Robert
 

--- a/R/toolAdjustEsDemand.R
+++ b/R/toolAdjustEsDemand.R
@@ -65,7 +65,7 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
                                     region = "CHN",
                                     variable = "Share_in_Vehicles",
                                     unit = "Percent",
-                                    value = c(70,9,7,3,11))
+                                    value = c(74,5,5,3,13))
 
 
   # ## For debugging: first create safe-copy to later check if only the wanted rows are changed. Outcomment for debugging.

--- a/R/toolAdjustEsDemand.R
+++ b/R/toolAdjustEsDemand.R
@@ -65,7 +65,7 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
                                     region = "CHN",
                                     variable = "Share_in_Vehicles",
                                     unit = "Percent",
-                                    value = c(61,11,9,5,14))
+                                    value = c(70,9,7,3,11))
 
 
   # ## For debugging: first create safe-copy to later check if only the wanted rows are changed. Outcomment for debugging.

--- a/R/toolAdjustEsDemand.R
+++ b/R/toolAdjustEsDemand.R
@@ -6,10 +6,11 @@
 #' @param mapIso2region map iso countries to regions
 #' @param completeData All combinations of region, period, univocalName and technology in EDGE-T decision tree
 #' @param filter list of filters for specific branches in the upper decision tree, containing all associated
+#' @param data source data containing the annual mileage and load factor
 #' univocalNames
 #' @return a quitte object
 
-toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter) {
+toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, data) {
   variable <- period  <- unit <- value <-  demldv <- regionCode21 <-
     regionCode12 <- region <- univocalName <- NULL
 
@@ -25,6 +26,8 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter) {
   # The missing modes get a zero demand for now. After the regional aggregation, the zero demand remains only
   # for alternative technologies
   dt[is.na(value), value := 0]
+
+
 
   #2: Add some base demand for Cycle & Walk (2%)
   dt[, demldv := sum(value), by = c("period", "region")]
@@ -47,6 +50,159 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter) {
      by = c("period", "region", "technology")]
   dt[region %in% c("CHN", "HKG", "MAC") & univocalName == "Truck (18t)", value := value / 2,
      by = c("period", "region", "technology")]
+
+  ######## new China stuff from Robert
+
+
+  # ## For debugging: first create safe-copy to later check if only the wanted rows are changed. Outcomment for debugging.
+  # dt_safecopy <- copy(dt)
+
+  # extract existing ES totals for regions and trucks of interest
+  histESdemandCHA <- dt[region %in% c("CHN") & univocalName %like% "Truck"]
+
+  histESdemandCHA_old <- histESdemandCHA[    # drop variable and unit
+    , .(value = sum(value)),
+    by = .(region, univocalName, technology, period )
+  ]
+
+  histESdemandCHA_old_size <- histESdemandCHA_old[
+    , .(old_ES = sum(value)),
+    by = .(region, univocalName, period)
+  ]
+
+  histESdemandCHA_old_total <- histESdemandCHA_old[
+    , .(total_ES = sum(value)),
+    by = .(region, period)
+  ]
+
+  # calculate new ES splits
+
+  ## define target vehicle shares by size:
+  ## this data is based on downscaled values from CEIC data, and further split to EDGE-T splits : 40t	5%, 26t	9%, 18t	11%, 7.5t	23%, 0-3.5 t 52%
+  ## The data can be found in the transport folder in the owncloud: "Data/RegionalData/compiling_CHA_data_heavy_duty_vehicles.xlsx", cells V17:V21
+
+  VehSharesTargetSize <- data.table(univocalName = c("Truck (0-3_5t)","Truck (18t)","Truck (26t)","Truck (40t)","Truck (7_5t)"),
+                                    region = "CHN",
+                                    variable = "Share_in_Vehicles",
+                                    unit = "Percent",
+                                    value = c(52,11,9,5,23))
+
+  ## Then calculate total tkm per vehicle from annual mileage and load factors.
+  ## Take the values for "Liquids", as that is the most common technology in 2010
+
+  annualTkmPerVehicleCol <- data$annualMileage[region %in% c("CHN") & univocalName %like% "Truck" & period == 2010 & technology == "Liquids",
+                                          .(annualMileage = value), by = .(region, univocalName)]
+
+  annualTkmPerVehicleCol <- annualTkmPerVehicleCol[data$loadFactor[region %in% c("CHN") & univocalName %like% "Truck" & period == 2010 & technology == "Liquids",
+                                                              .(loadFactor = loadFactor), by = .(region, univocalName)],
+                                                   on = .( univocalName, region)][
+                                                     , load_x_mileage := annualMileage * loadFactor
+                                                   ]
+
+
+  ## calculate resulting ES values by size
+  ESSharesTargetSize <- VehSharesTargetSize[
+    annualTkmPerVehicleCol,
+    on = .(univocalName, region)
+  ][
+    , ESsharesUnnormalized := value / 100 * load_x_mileage
+  ]
+
+  ESSharesTargetSize[ , ESsharesNormalized := ESsharesUnnormalized / sum(ESsharesUnnormalized),
+                      by = region
+  ]
+
+  ESSharesTargetSizeBack <- ESSharesTargetSize[ , .(univocalName = univocalName ,
+                                                    region = region,
+                                                    variable = "TargetShareES",
+                                                    unit = "Percent",
+                                                    value = ESsharesNormalized * 100)
+  ]
+
+
+  # calculate target ES per vehicle size with old ES totals
+  ## First create new DT with period x univocalname size, as SizeSharesTarget has no period, and histESdemandCHA_old_total no size
+
+  histESdemandCHA_target_size <- CJ(
+    period = histESdemandCHA_old_total$period,
+    univocalName = ESSharesTargetSizeBack$univocalName,
+    unique = TRUE
+  )[
+    ESSharesTargetSizeBack[, .(univocalName, ES_share = value / 100)],
+    on = "univocalName"
+  ][
+    histESdemandCHA_old_total,
+    on = "period"
+  ][
+    , target_ES := ES_share * total_ES
+  ]
+
+  ## calculate scaling factors for each size
+  ES_scaling <- histESdemandCHA_old_size[
+    histESdemandCHA_target_size,
+    on = .(period, univocalName, region)
+  ][
+    , scaling := target_ES / old_ES
+  ]
+
+  ## rescale using old ES totals:
+  histESdemandCHA_newES <- histESdemandCHA_old[
+    ES_scaling,
+    on = .(period, univocalName, region)
+  ][
+    , value := value * scaling
+  ]
+
+  ## drop unused columns, add variable and unit
+  histESdemandCHA_newES[, c("old_ES", "ES_share", "total_ES", "target_ES", "scaling") := NULL][, ':='(variable = "ES", unit = "billion tkm/yr")]
+
+  ## check that the total new ES and the total old ES are unchanged:
+  stopifnot(
+    all.equal(
+      histESdemandCHA_newES[, sum(value), by = period],
+      histESdemandCHA[, sum(value), by = period]
+    )
+  )
+
+  ## overwrite the data in dt:
+
+  join_cols <- c("region", "univocalName", "technology", "variable","unit", "period")
+
+  dt[
+    histESdemandCHA_newES,
+    on = join_cols,
+    value := i.value
+  ]
+
+  # ## For debugging: check which values were changed:
+  # # Outcomment for debugging.
+  #
+  # key_cols <- c("period", "region", "univocalName", "technology", "variable")
+  #
+  # dt_diff <- dt[
+  #   dt_safecopy,
+  #   on = key_cols,
+  #   nomatch = 0,
+  #   .(
+  #     period,
+  #     region,
+  #     univocalName,
+  #     technology,
+  #     variable,
+  #     value_new = value,
+  #     value_old = i.value
+  #   )
+  # ]
+  # dt_changed <- dt_diff[value_new != value_old]
+
+  ## is it necessary / advised to clean up, or is this anyway all deleted because the function only returns dt ??
+  histESdemandCHA        <- NULL
+  histESdemandCHA_newES  <- NULL
+  histESdemandCHA_target_size <- NULL
+  ESSharesTargetSize    <- NULL
+
+  ############ end of new CHA stuff from Robert
+
   dt[region %in% c("USA", "PRI", "UMI", "VIR"), value := ifelse(univocalName == "Truck (26t)",
                                                                 value[univocalName == "Truck (18t)"] / 3,
                                                                 value),

--- a/R/toolAdjustEsDemand.R
+++ b/R/toolAdjustEsDemand.R
@@ -193,6 +193,20 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
   # ]
   # dt_changed <- dt_diff[value_new != value_old]
 
+  ###### also adjust car ES demands upwards to better reflect car stock numbers in 2010 (~62 mio, eg IEA GEVO and others - see file in the owncloud
+  ## "Data/RegionalData/compiling_CHA_data_LDV.xlsx",
+  ## Simply increasing the ES values means that more cars are on the road, but also that 2010 FE demand BEFORE the IEA calibration is higher - thus preventing
+  ## the strong upscaling of energy intensities during the IEA FE calibration that was previously the case.
+
+  carTypes <- c("Compact Car", "Large Car", "Large Car and SUV", "Midsize Car", "Mini Car", "Subcompact Car","Van")
+
+  dt[univocalName %in% carTypes & region == "CHN" & period == 2010, value := 2 * value]
+  dt[univocalName %in% carTypes & region == "CHN" & period == 2009, value := 1.9 * value]
+  dt[univocalName %in% carTypes & region == "CHN" & period == 2008, value := 1.8 * value]
+  dt[univocalName %in% carTypes & region == "CHN" & period == 2007, value := 1.7 * value]
+  dt[univocalName %in% carTypes & region == "CHN" & period == 2006, value := 1.6 * value]
+  dt[univocalName %in% carTypes & region == "CHN" & period <= 2005, value := 1.5 * value]
+
   ############ end of new CHA stuff from Robert
 
   dt[region %in% c("USA", "PRI", "UMI", "VIR"), value := ifelse(univocalName == "Truck (26t)",

--- a/R/toolAdjustEsDemand.R
+++ b/R/toolAdjustEsDemand.R
@@ -200,12 +200,12 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
 
   carTypes <- c("Compact Car", "Large Car", "Large Car and SUV", "Midsize Car", "Mini Car", "Subcompact Car","Van")
 
-  dt[univocalName %in% carTypes & region == "CHN" & period == 2010, value := 2 * value]
-  dt[univocalName %in% carTypes & region == "CHN" & period == 2009, value := 1.9 * value]
-  dt[univocalName %in% carTypes & region == "CHN" & period == 2008, value := 1.8 * value]
-  dt[univocalName %in% carTypes & region == "CHN" & period == 2007, value := 1.7 * value]
-  dt[univocalName %in% carTypes & region == "CHN" & period == 2006, value := 1.6 * value]
-  dt[univocalName %in% carTypes & region == "CHN" & period <= 2005, value := 1.5 * value]
+  dt[univocalName %in% carTypes & region == "CHN" , value := 3 * value]
+  # dt[univocalName %in% carTypes & region == "CHN" & period == 2009, value := 1.9 * value]
+  # dt[univocalName %in% carTypes & region == "CHN" & period == 2008, value := 1.8 * value]
+  # dt[univocalName %in% carTypes & region == "CHN" & period == 2007, value := 1.7 * value]
+  # dt[univocalName %in% carTypes & region == "CHN" & period == 2006, value := 1.6 * value]
+  # dt[univocalName %in% carTypes & region == "CHN" & period <= 2005, value := 1.5 * value]
 
   ############ end of new CHA stuff from Robert
 

--- a/R/toolAdjustEsDemand.R
+++ b/R/toolAdjustEsDemand.R
@@ -51,9 +51,12 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
   dt[region %in% c("CHN", "HKG", "MAC") & univocalName == "Truck (18t)", value := value / 2,
      by = c("period", "region", "technology")]
 
-  ######## new China truck size adjustment from Robert
-
+  ######## new historic truck size adjustment from Robert for CHN and JPN
   ## Adjustments on truck size classes in CHN region according to newer data and model results
+
+  ## when combining the input data ES values by size with the input data annualMileage and loadFactor, the following shares come out:
+  ## 40t 0.1%, 26t 0.4%, 18t 1.4%, 7.5t 3%, 0-3.5t 95%
+
   ## The new data is based on downscaled values from CEIC data, https://www.ceicdata.com/en/china/no-of-motor-vehicle/cn-no-of-motor-vehicle-truck-heavy
   ## It is further split to EDGE-T size classes : 40t	5%, 26t	9%, 18t	11%, 7.5t	11%, 0-3.5 t 64%
   ## The original data and the further processing can be found in the transport folder in the owncloud:
@@ -61,8 +64,13 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
 
   ## However, the real-world split produces too low truck numbers when combined with the rest of the input data (total ES, enIntensity, loadFactor, ...)
   ## Therefore, the following values are used, which are closer to the real-world values than the original data from GCAM, and still produce reasonable 2010/2015 truck numbers
-  ## 40t	2%, 26t	3%, 18t	4%, 7.5t	13%, 0-3.5 t 78%
+  ## 40t 3%, 26t 3%, 18t 5%, 7.5t 13%, 0-3.5t 76%
   ## When the rest of the input data is improved, this here should be changed to the real-world data as well.
+
+  ## Also the truck size data for JPN is overwritten, as our input data for JPN shows 99.999% of 0-3.5t trucks, while recent real-world data shows relevant numbers of heavy-duty trucks.
+  ## "Data/RegionalData/compiling_JPN_data_heavy_duty_vehicles.xlsx"
+  ## At the moment, the current vehicle size shares are:  (to be changed in the future once other input data is adjusted)
+  ## 40t 3%, 26t 3%, 18t 5%, 7.5t 13%, 0-3.5t 76%
 
   # First step: define target vehicle shares by size:
   VehSharesTargetSize <- data.table(univocalName = c("Truck (0-3_5t)","Truck (18t)","Truck (26t)","Truck (40t)","Truck (7_5t)"),
@@ -112,8 +120,10 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
   annualTkmPerVehicle <- histSourceData$annualMileage[region %in% c("CHN","JPN") & univocalName %like% "Truck" & period == 2010 & technology == "Liquids",
                                                       .(annualMileage = value), by = .(region, univocalName)]
 
-  annualTkmPerVehicle <- merge(annualTkmPerVehicle, histSourceData$loadFactor[region %in% c("CHN","JPN") & univocalName %like% "Truck" & period == 2010 & technology == "Liquids",
-                                                                              .(loadFactor = loadFactor), by = .(region, univocalName)],
+  dtloadFactor <- histSourceData$loadFactor[region %in% c("CHN","JPN") & univocalName %like% "Truck" & period == 2010 & technology == "Liquids",
+                                            .(loadFactor = loadFactor), by = .(region, univocalName)]
+
+  annualTkmPerVehicle <- merge(annualTkmPerVehicle, dtloadFactor,
                                by = c("region", "univocalName"))
 
   annualTkmPerVehicle[, ESperVeh := annualMileage * loadFactor ]
@@ -212,10 +222,12 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
   # ]
   # dt_changed <- dt_diff[value_new != value_old]
 
-  ###### also adjust car ES demands upwards to better reflect car stock numbers in 2010 (~62 mio, eg IEA GEVO and others - see file in the owncloud
-  ## "Data/RegionalData/compiling_CHA_data_LDV.xlsx",
-  ## Simply increasing the ES values means that more cars are on the road, but also that 2010 FE demand BEFORE the IEA calibration is higher - thus preventing
+  ###### also adjust car ES demands upwards to better reflect car stock numbers in 2010 and 2015
+  ## (~62 mio in 2010, 140 mio in 2015 , eg IEA GEVO and others - see file in the owncloud "Data/RegionalData/compiling_CHA_data_LDV.xlsx",
+  ## Increasing the ES values means that more cars are on the road, but also that 2010 FE demand BEFORE the IEA calibration is higher - thus preventing
   ## the strong upscaling of energy intensities during the IEA FE calibration that was previously the case.
+  ## The multipliers are staggered (reducing from 2.5 in 2010 to 1.5 in 2005) to represent the fast growth of LDV numbers over these 5 years.
+  ## The 2.5 multiplier in 2010 is a compromise betwen hitting 2010 and 2015 numbers: 2010 85 mio instead of 62 mio, 2015 125 mio instead of 140 mio
 
   carTypes <- c("Compact Car", "Large Car", "Large Car and SUV", "Midsize Car", "Mini Car", "Subcompact Car","Van")
 

--- a/R/toolAdjustEsDemand.R
+++ b/R/toolAdjustEsDemand.R
@@ -54,18 +54,23 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
 
   ######## new China truck size adjustment from Robert
 
-  ## Adjustments on truck size classes in CHN region according to newer data.
-  ## This data is based on downscaled values from CEIC data, https://www.ceicdata.com/en/china/no-of-motor-vehicle/cn-no-of-motor-vehicle-truck-heavy
-  ## It is further split to EDGE-T size classes : 40t	5%, 26t	9%, 18t	11%, 7.5t	14%, 0-3.5 t 61%
+  ## Adjustments on truck size classes in CHN region according to newer data and model results
+  ## The new data is based on downscaled values from CEIC data, https://www.ceicdata.com/en/china/no-of-motor-vehicle/cn-no-of-motor-vehicle-truck-heavy
+  ## It is further split to EDGE-T size classes : 40t	5%, 26t	9%, 18t	11%, 7.5t	11%, 0-3.5 t 64%
   ## The original data and the further processing can be found in the transport folder in the owncloud:
   ## "Data/RegionalData/compiling_CHA_data_heavy_duty_vehicles.xlsx", cells V17:V21
+
+  ## However, the real-world split produces too low truck numbers when combined with the rest of the input data (total ES, enIntensity, loadFactor, ...)
+  ## Therefore, the following values are used, which are closer to the real-world values than the original data from GCAM, and still produce reasonable 2010/2015 truck numbers
+  ## 40t	2%, 26t	3%, 18t	4%, 7.5t	13%, 0-3.5 t 78%
+  ## When the rest of the input data is improved, this here should be changed to the real-world data as well.
 
   # First step: define target vehicle shares by size:
   VehSharesTargetSize <- data.table(univocalName = c("Truck (0-3_5t)","Truck (18t)","Truck (26t)","Truck (40t)","Truck (7_5t)"),
                                     region = "CHN",
                                     variable = "Share_in_Vehicles",
                                     unit = "Percent",
-                                    value = c(74,5,5,3,13))
+                                    value = c(78,4,3,2,13))
 
 
   # ## For debugging: first create safe-copy to later check if only the wanted rows are changed. Outcomment for debugging.
@@ -201,11 +206,11 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
   carTypes <- c("Compact Car", "Large Car", "Large Car and SUV", "Midsize Car", "Mini Car", "Subcompact Car","Van")
 
   dt[univocalName %in% carTypes & region == "CHN" , value := 3 * value]
-  # dt[univocalName %in% carTypes & region == "CHN" & period == 2009, value := 1.9 * value]
-  # dt[univocalName %in% carTypes & region == "CHN" & period == 2008, value := 1.8 * value]
-  # dt[univocalName %in% carTypes & region == "CHN" & period == 2007, value := 1.7 * value]
-  # dt[univocalName %in% carTypes & region == "CHN" & period == 2006, value := 1.6 * value]
-  # dt[univocalName %in% carTypes & region == "CHN" & period <= 2005, value := 1.5 * value]
+  dt[univocalName %in% carTypes & region == "CHN" & period == 2009, value := 2.8 * value]
+  dt[univocalName %in% carTypes & region == "CHN" & period == 2008, value := 2.6 * value]
+  dt[univocalName %in% carTypes & region == "CHN" & period == 2007, value := 2.4 * value]
+  dt[univocalName %in% carTypes & region == "CHN" & period == 2006, value := 2.2 * value]
+  dt[univocalName %in% carTypes & region == "CHN" & period <= 2005, value := 2   * value]
 
   ############ end of new CHA stuff from Robert
 

--- a/R/toolAdjustEsDemand.R
+++ b/R/toolAdjustEsDemand.R
@@ -51,7 +51,6 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
   dt[region %in% c("CHN", "HKG", "MAC") & univocalName == "Truck (18t)", value := value / 2,
      by = c("period", "region", "technology")]
 
-
   ######## new China truck size adjustment from Robert
 
   ## Adjustments on truck size classes in CHN region according to newer data and model results
@@ -142,23 +141,7 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
   ]
 
   # calculate target ES per vehicle size with old ES totals
-  ## First create new DT with period x univocalname size, as SizeSharesTarget has no period, and histESdemandtoUpdateoldTotal no size
-
-  histESdemandtoUpdatetargetPerSize <- CJ(
-    period = histESdemandtoUpdateoldTotal$period,
-    univocalName = ESSharesTargetSizeBack$univocalName,
-    unique = TRUE
-  )[
-    ESSharesTargetSizeBack[, .(univocalName, ESshare = value / 100)],
-    on = c("univocalName","region"),
-    allow.cartesian = TRUE
-  ][
-    histESdemandtoUpdateoldTotal,
-    on = "period",
-    allow.cartesian = TRUE
-  ]
-
-  histESdemandtoUpdatetargetPerSize <- NULL
+  ## First create new DT with period x univocalname size with the "allow.cartesian = TRUE, as SizeSharesTarget has no period, and histESdemandtoUpdateoldTotal no size
 
   histESdemandtoUpdatetargetPerSize <- ESSharesTargetSizeBack[
     histESdemandtoUpdateoldTotal,

--- a/R/toolAdjustEsDemand.R
+++ b/R/toolAdjustEsDemand.R
@@ -37,23 +37,9 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
   dt[univocalName == "Cycle" & value == 0 & regionCode21 %in% c("IND", "CHN"), value := demldv * 0.02]
   dt[, demldv := NULL]
 
-  #3: Correct demand for CHN
-  ## the category "truck > 14t" in China does most likely contain also heavy trucks
-  ## otherwise there are none
-  #plausibilityFix_CHN #plausibilityFix_Truck #plausibilityFix_Freight
-  dt[region %in% c("CHN", "HKG", "MAC"), value := ifelse(univocalName == "Truck (26t)",
-                                                         value[univocalName == "Truck (18t)"] / 4,
-                                                         value),
-     by = c("period", "region", "technology")]
-  dt[region %in% c("CHN", "HKG", "MAC"), value := ifelse(univocalName == "Truck (40t)",
-                                                         value[univocalName == "Truck (18t)"] / 4,
-                                                         value),
-     by = c("period", "region", "technology")]
-  dt[region %in% c("CHN", "HKG", "MAC") & univocalName == "Truck (18t)", value := value / 2,
-     by = c("period", "region", "technology")]
-
-  ######## new historic truck size adjustment from Robert for CHN and JPN
+  #3: Correct truck size ES splits for CHA and JPN
   #plausibilityFix_CHN #plausibilityFix_JPN #plausibilityFix_Truck #plausibilityFix_Freight
+
   ## Adjustments on truck size classes in CHN region according to newer data and model results
   ## Treat HKG and MAC like CHN, as we have no data on their specific size split
 
@@ -74,7 +60,7 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
   ## "Data/RegionalData/compiling_JPN_data_heavy_duty_vehicles.xlsx"
   ## At the moment, the current vehicle size shares are:  (to be changed in the future once other input data is adjusted)
   ## 40t 3%, 26t 3%, 18t 5%, 7.5t 13%, 0-3.5t 76%
-browser()
+
   # First step: define target vehicle shares by size:
   VehSharesTargetSize <- data.table(univocalName = c("Truck (0-3_5t)", "Truck (18t)", "Truck (26t)", "Truck (40t)", "Truck (7_5t)"),
                                     region = c(rep("CHN", 5), rep("HKG", 5), rep("MAC", 5), rep("JPN", 5)),
@@ -102,6 +88,21 @@ browser()
   histESdemandtoUpdateold[ region == "JPN" & univocalName %in% c("Truck (18t)", "Truck (40t)", "Truck (7_5t)", "Truck (26t)") & technology == "Liquids",
                            value := MinEsValuePerSize ]
 
+  ## The same problem of zero-value entries holds true for CHA, but for CHA the technology split is more relevant,
+  ## as CHA has a relevant CNG truck fleet.
+  ## Therefore, the initialization is based on the technology split of 18t-trucks:
+
+  histESdemandtoUpdateold[region %in% c("CHN", "HKG", "MAC"), value := ifelse(univocalName == "Truck (26t)",
+                                                         value[univocalName == "Truck (18t)"] * 1e-4,
+                                                         value),
+     by = c("period", "region", "technology")]
+  histESdemandtoUpdateold[region %in% c("CHN", "HKG", "MAC"), value := ifelse(univocalName == "Truck (40t)",
+                                                         value[univocalName == "Truck (18t)"] * 1e-4,
+                                                         value),
+     by = c("period", "region", "technology")]
+
+
+  ## calculate totals by truck size and overall total truck ES
 
   histESdemandtoUpdateoldSize <- histESdemandtoUpdateold[
     , .(oldES = sum(value)),
@@ -130,7 +131,7 @@ browser()
   annualTkmPerVehicle[, ESperVeh := annualMileage * loadFactor ]
 
 
-  # calculate old truck shares per vehicle size
+  # calculate old truck shares per vehicle size as coming from the original input data
 
   VehicleOverview <- merge(annualTkmPerVehicle, histESdemandtoUpdateoldSize [period == 2010],
                            by = c("region", "univocalName"))
@@ -191,37 +192,13 @@ browser()
     )
   )
 
-  ## update the original dt
-  ## the "value := i.value" formulation overwrites only the rows in dt that are contained in histESdemandtoUpdatenewES, and keeps everyhting else unchanged:
 
-  joinCols <- c("region", "univocalName", "technology", "variable","unit", "period")
+  ## update the original dt - overwrite values for which there are new values in histESdemandtoUpdatenewES
+  setnames(histESdemandtoUpdatenewES, "value", "valueNew")
+  dt <- merge(dt, histESdemandtoUpdatenewES, by = intersect(names(dt), names(histESdemandtoUpdatenewES)), all.x = TRUE)
+  dt[!is.na(valueNew), value := valueNew][, valueNew := NULL]
 
-  dt[
-    histESdemandtoUpdatenewES,
-    on = joinCols,
-    value := i.value
-  ]
 
-  # ## For debugging: check which values were changed:
-  # # Outcomment for debugging.
-  #
-  # key_cols <- c("period", "region", "univocalName", "technology", "variable")
-  #
-  # dt_diff <- dt[
-  #   dt_safecopy,
-  #   on = key_cols,
-  #   nomatch = 0,
-  #   .(
-  #     period,
-  #     region,
-  #     univocalName,
-  #     technology,
-  #     variable,
-  #     value_new = value,
-  #     value_old = i.value
-  #   )
-  # ]
-  # dt_changed <- dt_diff[value_new != value_old]
 
   ###### also adjust car ES demands upwards to better reflect car stock numbers in 2010 and 2015
   ## (~62 mio in 2010, 140 mio in 2015 , eg IEA GEVO and others - see file in the owncloud "Data/RegionalData/compiling_CHA_data_LDV.xlsx",

--- a/R/toolAdjustEsDemand.R
+++ b/R/toolAdjustEsDemand.R
@@ -40,6 +40,7 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
   #3: Correct demand for CHN
   ## the category "truck > 14t" in China does most likely contain also heavy trucks
   ## otherwise there are none
+  #plausibilityFix_CHN #plausibilityFix_Truck #plausibilityFix_Freight
   dt[region %in% c("CHN", "HKG", "MAC"), value := ifelse(univocalName == "Truck (26t)",
                                                          value[univocalName == "Truck (18t)"] / 4,
                                                          value),
@@ -52,7 +53,9 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
      by = c("period", "region", "technology")]
 
   ######## new historic truck size adjustment from Robert for CHN and JPN
+  #plausibilityFix_CHN #plausibilityFix_JPN #plausibilityFix_Truck #plausibilityFix_Freight
   ## Adjustments on truck size classes in CHN region according to newer data and model results
+  ## Treat HKG and MAC like CHN, as we have no data on their specific size split
 
   ## when combining the input data ES values by size with the input data annualMileage and loadFactor, the following shares come out:
   ## 40t 0.1%, 26t 0.4%, 18t 1.4%, 7.5t 3%, 0-3.5t 95%
@@ -71,18 +74,16 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
   ## "Data/RegionalData/compiling_JPN_data_heavy_duty_vehicles.xlsx"
   ## At the moment, the current vehicle size shares are:  (to be changed in the future once other input data is adjusted)
   ## 40t 3%, 26t 3%, 18t 5%, 7.5t 13%, 0-3.5t 76%
-
+browser()
   # First step: define target vehicle shares by size:
-  VehSharesTargetSize <- data.table(univocalName = c("Truck (0-3_5t)","Truck (18t)","Truck (26t)","Truck (40t)","Truck (7_5t)"),
-                                    region = c(rep("CHN",5),rep("JPN",5)),
+  VehSharesTargetSize <- data.table(univocalName = c("Truck (0-3_5t)", "Truck (18t)", "Truck (26t)", "Truck (40t)", "Truck (7_5t)"),
+                                    region = c(rep("CHN", 5), rep("HKG", 5), rep("MAC", 5), rep("JPN", 5)),
                                     variable = "Share_in_Vehicles",
                                     unit = "Percent",
-                                    value = c( c(76, 5, 3, 3, 13), c(88,1,1,1,9)))
-
-
+                                    value = c( rep(c(76, 5, 3, 3, 13), 3), c(88, 1, 1, 1, 9)))
 
   # extract existing ES totals for regions and trucks of interest
-  histESdemandtoUpdate <- dt[region %in% c("CHN","JPN") & univocalName %like% "Truck"]
+  histESdemandtoUpdate <- dt[region %in% c("CHN", "HKG", "MAC", "JPN") & univocalName %like% "Truck"]
 
   histESdemandtoUpdateold <- histESdemandtoUpdate[    # drop variable and unit
     , .(value = value),
@@ -117,10 +118,10 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
   ## First calculate total tkm per vehicle from annual mileage and load factors.
   ## Take the values for "Liquids", as that is the most common technology in 2010
 
-  annualTkmPerVehicle <- histSourceData$annualMileage[region %in% c("CHN","JPN") & univocalName %like% "Truck" & period == 2010 & technology == "Liquids",
+  annualTkmPerVehicle <- histSourceData$annualMileage[region %in% c("CHN", "HKG", "MAC", "JPN") & univocalName %like% "Truck" & period == 2010 & technology == "Liquids",
                                                       .(annualMileage = value), by = .(region, univocalName)]
 
-  dtloadFactor <- histSourceData$loadFactor[region %in% c("CHN","JPN") & univocalName %like% "Truck" & period == 2010 & technology == "Liquids",
+  dtloadFactor <- histSourceData$loadFactor[region %in% c("CHN", "HKG", "MAC", "JPN") & univocalName %like% "Truck" & period == 2010 & technology == "Liquids",
                                             .(loadFactor = loadFactor), by = .(region, univocalName)]
 
   annualTkmPerVehicle <- merge(annualTkmPerVehicle, dtloadFactor,
@@ -228,6 +229,7 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
   ## the strong upscaling of energy intensities during the IEA FE calibration that was previously the case.
   ## The multipliers are staggered (reducing from 2.5 in 2010 to 1.5 in 2005) to represent the fast growth of LDV numbers over these 5 years.
   ## The 2.5 multiplier in 2010 is a compromise betwen hitting 2010 and 2015 numbers: 2010 85 mio instead of 62 mio, 2015 125 mio instead of 140 mio
+  #plausibilityFix_CHN #plausibilityFix_LDV #plausibilityFix_Pass
 
   carTypes <- c("Compact Car", "Large Car", "Large Car and SUV", "Midsize Car", "Mini Car", "Subcompact Car","Van")
 
@@ -240,6 +242,7 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
 
   ############ end of new CHA stuff from Robert
 
+  #plausibilityFix_USA #plausibilityFix_Truck #plausibilityFix_Freight
   dt[region %in% c("USA", "PRI", "UMI", "VIR"), value := ifelse(univocalName == "Truck (26t)",
                                                                 value[univocalName == "Truck (18t)"] / 3,
                                                                 value),
@@ -251,25 +254,32 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
   dt[region %in% c("USA", "PRI", "UMI", "VIR") & univocalName == "Truck (18t)", value := value / 3,
      by = c("period", "region", "technology")]
 
+
+  #plausibilityFix_CHN #plausibilityFix_Rail #plausibilityFix_Pass
   #from https://www.iea.org/reports/tracking-rail-2020-2
   dt[period <= 2010 & regionCode21 == "CHN" & univocalName == "HSR", value := 70000]
+
+  #plausibilityFix_CHN #plausibilityFix_Truck #plausibilityFix_Freight
   # from https://theicct.org/sites/default/files/China_Freight_Assessment_English_20181022.pdf
   # total road freight demand seems to be around 5 billion tkm * 0.8, a factor 3 roughly
   dt[period <= 2010 & regionCode21 == "CHN" & univocalName %in% filter$trn_freight_road, value := value * 3]
 
   #4: Demand level corrections, adjusting to ETP demands
+  #plausibilityFix_CHN #plausibilityFix_Bus #plausibilityFix_Pass   #plausibilityFix_IND #plausibilityFix_OAS #plausibilityFix_NEU #plausibilityFix_MEA
   dt[regionCode21 == "CHA" & univocalName == "Bus", value := value / 2.5]
   dt[regionCode21 == "IND" & univocalName == "Bus", value := value / 2]
   dt[regionCode21 == "OAS" & univocalName == "Bus", value := value / 5]
   dt[regionCode12 == "NEU" & univocalName == "Bus", value := value / 2]
   dt[regionCode21 == "MEA" & univocalName == "Bus", value := value / 2]
 
+  #plausibilityFix_DEU #plausibilityFix_Truck #plausibilityFix_Freight
   #5: Adjust GER Truck size shares according to KBA data (calculated from stocks via AM and LF)
   dt[region == "DEU" & univocalName == "Truck (0-3_5t)", value := value * 2]
   dt[region == "DEU" & univocalName == "Truck (7_5t)", value := value * 0.25]
   dt[region == "DEU" & univocalName == "Truck (18t)", value := value * 0.65]
   dt[region == "DEU" & univocalName == "Truck (40t)", value := value * 1.4]
 
+  #plausibilityFix_DEU #plausibilityFix_Truck #plausibilityFix_Freight
   #6: Total 2010 Freight demands, from ViZ 2010
   # (the shares are roughly OK)
   dt[region == "DEU" & univocalName %in% filter$trn_freight, value := value * 620 / 587]

--- a/R/toolAdjustEsDemand.R
+++ b/R/toolAdjustEsDemand.R
@@ -67,30 +67,41 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
 
   # First step: define target vehicle shares by size:
   VehSharesTargetSize <- data.table(univocalName = c("Truck (0-3_5t)","Truck (18t)","Truck (26t)","Truck (40t)","Truck (7_5t)"),
-                                    region = "CHN",
+                                    region = c(rep("CHN",5),rep("JPN",5)),
                                     variable = "Share_in_Vehicles",
                                     unit = "Percent",
-                                    value = c(78,4,3,2,13))
+                                    value = c( c(76, 5, 3, 3, 13), c(85,3,2,1,9)))
 
 
-  # ## For debugging: first create safe-copy to later check if only the wanted rows are changed. Outcomment for debugging.
-  dt_safecopy <- copy(dt)
 
   # extract existing ES totals for regions and trucks of interest
-  histESdemandCHA <- dt[region %in% c("CHN") & univocalName %like% "Truck"]
+  histESdemandtoUpdate <- dt[region %in% c("CHN","JPN") & univocalName %like% "Truck"]
 
-  histESdemandCHAold <- histESdemandCHA[    # drop variable and unit
-    , .(value = sum(value)),
+  histESdemandtoUpdateold <- histESdemandtoUpdate[    # drop variable and unit
+    , .(value = value),
     by = .(region, univocalName, technology, period )
   ]
 
-  histESdemandCHAoldSize <- histESdemandCHAold[
+  histESdemandtoUpdateoldTotal <- histESdemandtoUpdateold[
+    , .(totalES = sum(value)),
+    by = .(region, period)
+  ]
+
+  ## for Japan, truck sizes > 3.5 are completely missing from the input data. This makes the later rescaling impossible.
+  ## Therefore, I overwrite them with 1e-4 * min(totalES) to have a basis for rescaling, without changing totalES relevantly.
+  ## The "min" ensures that really the smallest ES value in any of the observed regions is used, to ensure minimal change of totalES
+  MinEsValuePerSize = 1e-4 * min(histESdemandtoUpdateoldTotal$totalES)
+  histESdemandtoUpdateold[ region == "JPN" & univocalName %in% c("Truck (18t)", "Truck (40t)", "Truck (7_5t)", "Truck (26t)") & technology == "Liquids",
+                           value := MinEsValuePerSize ]
+
+
+  histESdemandtoUpdateoldSize <- histESdemandtoUpdateold[
     , .(oldES = sum(value)),
     by = .(region, univocalName, period)
   ]
 
-  histESdemandCHAoldTotal <- histESdemandCHAold[
-    , .(total_ES = sum(value)),
+  histESdemandtoUpdateoldTotal <- histESdemandtoUpdateold[
+    , .(totalES = sum(value)),
     by = .(region, period)
   ]
 
@@ -99,15 +110,24 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
   ## First calculate total tkm per vehicle from annual mileage and load factors.
   ## Take the values for "Liquids", as that is the most common technology in 2010
 
-  annualTkmPerVehicle <- histSourceData$annualMileage[region %in% c("CHN") & univocalName %like% "Truck" & period == 2010 & technology == "Liquids",
-                                          .(annualMileage = value), by = .(region, univocalName)]
+  annualTkmPerVehicle <- histSourceData$annualMileage[region %in% c("CHN","JPN") & univocalName %like% "Truck" & period == 2010 & technology == "Liquids",
+                                                      .(annualMileage = value), by = .(region, univocalName)]
 
-  annualTkmPerVehicle <- merge(annualTkmPerVehicle, histSourceData$loadFactor[region %in% c("CHN") & univocalName %like% "Truck" & period == 2010 & technology == "Liquids",
-                                                                    .(loadFactor = loadFactor), by = .(region, univocalName)],
+  annualTkmPerVehicle <- merge(annualTkmPerVehicle, histSourceData$loadFactor[region %in% c("CHN","JPN") & univocalName %like% "Truck" & period == 2010 & technology == "Liquids",
+                                                                              .(loadFactor = loadFactor), by = .(region, univocalName)],
                                by = c("region", "univocalName"))
 
   annualTkmPerVehicle[, ESperVeh := annualMileage * loadFactor ]
 
+
+  # calculate old truck shares per vehicle size
+
+  VehicleOverview <- merge(annualTkmPerVehicle, histESdemandtoUpdateoldSize [period == 2010],
+                           by = c("region", "univocalName"))
+
+  VehicleOverview[, NumOfTrucks := oldES / ESperVeh ]
+  VehicleOverview[, TotalNumOfTrucks := sum(NumOfTrucks), , by = region]
+  VehicleOverview[, ShareOfTruckSize := NumOfTrucks / TotalNumOfTrucks * 100, by = region]
 
   ## calculate resulting ES values by size
   ESSharesTargetSize <- merge(VehSharesTargetSize, annualTkmPerVehicle, by = c("region", "univocalName") )
@@ -118,61 +138,72 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
 
   ESSharesTargetSizeBack <- ESSharesTargetSize[ , .(univocalName = univocalName ,
                                                     region = region,
-                                                    variable = "TargetShareES",
-                                                    unit = "Percent",
-                                                    value = ESsharesNormalized * 100)
+                                                    ESshare = ESsharesNormalized)
   ]
 
   # calculate target ES per vehicle size with old ES totals
-  ## First create new DT with period x univocalname size, as SizeSharesTarget has no period, and histESdemandCHAoldTotal no size
+  ## First create new DT with period x univocalname size, as SizeSharesTarget has no period, and histESdemandtoUpdateoldTotal no size
 
-  histESdemandCHAtargetPerSize <- CJ(
-    period = histESdemandCHAoldTotal$period,
+  histESdemandtoUpdatetargetPerSize <- CJ(
+    period = histESdemandtoUpdateoldTotal$period,
     univocalName = ESSharesTargetSizeBack$univocalName,
     unique = TRUE
   )[
     ESSharesTargetSizeBack[, .(univocalName, ESshare = value / 100)],
-    on = "univocalName"
+    on = c("univocalName","region"),
+    allow.cartesian = TRUE
   ][
-    histESdemandCHAoldTotal,
-    on = "period"
+    histESdemandtoUpdateoldTotal,
+    on = "period",
+    allow.cartesian = TRUE
   ]
 
+  histESdemandtoUpdatetargetPerSize <- NULL
 
-  histESdemandCHAtargetPerSize[ , targetES := ESshare * total_ES ]
+  histESdemandtoUpdatetargetPerSize <- ESSharesTargetSizeBack[
+    histESdemandtoUpdateoldTotal,
+    on = "region",
+    allow.cartesian = TRUE
+  ]
+
+  histESdemandtoUpdatetargetPerSize[
+    , targetES := ESshare * totalES
+  ]
+
+  histESdemandtoUpdatetargetPerSize[ , targetES := ESshare * totalES ]
 
   ## calculate scaling factors for each size
-  ESscaling <- merge(histESdemandCHAoldSize, histESdemandCHAtargetPerSize, by = c("period", "univocalName", "region") )
+  ESscaling <- merge(histESdemandtoUpdateoldSize, histESdemandtoUpdatetargetPerSize, by = c("period", "univocalName", "region") )
 
   ESscaling[ , scaling := targetES / oldES ]
 
   ## rescale using old ES totals:
-  histESdemandCHAnewES <- merge(histESdemandCHAold, ESscaling, by = c("period", "univocalName", "region") )
+  histESdemandtoUpdatenewES <- merge(histESdemandtoUpdateold, ESscaling, by = c("period", "univocalName", "region") )
 
-  histESdemandCHAnewES[, value := value * scaling ]
+  histESdemandtoUpdatenewES[, value := value * scaling ]
 
   ## drop unused columns, add variable and unit
-  histESdemandCHAnewES[, c("oldES", "ESshare", "total_ES", "targetES", "scaling") := NULL][, ':='(variable = "ES", unit = "billion tkm/yr")]
+  histESdemandtoUpdatenewES[, c("oldES", "ESshare", "totalES", "targetES", "scaling") := NULL][, ':='(variable = "ES", unit = "billion tkm/yr")]
 
   ## check that the total new ES and the total old ES are unchanged:
 
-  setkey(histESdemandCHAnewES,region)
-  setkey(histESdemandCHAold,region)
+  setkey(histESdemandtoUpdatenewES,region)
+  setkey(histESdemandtoUpdateold,region)
 
   stopifnot(
     all.equal(
-      histESdemandCHAnewES[, sum(value), by = period],
-      histESdemandCHAold[, sum(value), by = period]
+      histESdemandtoUpdatenewES[, sum(value), by = .(period,region)],
+      histESdemandtoUpdateold[, sum(value), by = .(period,region)]
     )
   )
 
   ## update the original dt
-  ## the "value := i.value" formulation overwrites only the rows in dt that are contained in histESdemandCHAnewES, and keeps everyhting else unchanged:
+  ## the "value := i.value" formulation overwrites only the rows in dt that are contained in histESdemandtoUpdatenewES, and keeps everyhting else unchanged:
 
   joinCols <- c("region", "univocalName", "technology", "variable","unit", "period")
 
   dt[
-    histESdemandCHAnewES,
+    histESdemandtoUpdatenewES,
     on = joinCols,
     value := i.value
   ]
@@ -205,7 +236,7 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
 
   carTypes <- c("Compact Car", "Large Car", "Large Car and SUV", "Midsize Car", "Mini Car", "Subcompact Car","Van")
 
-  dt[univocalName %in% carTypes & region == "CHN" , value := 3 * value]
+  dt[univocalName %in% carTypes & region == "CHN" & period == 2010, value := 3 * value]
   dt[univocalName %in% carTypes & region == "CHN" & period == 2009, value := 2.8 * value]
   dt[univocalName %in% carTypes & region == "CHN" & period == 2008, value := 2.6 * value]
   dt[univocalName %in% carTypes & region == "CHN" & period == 2007, value := 2.4 * value]

--- a/R/toolAdjustEsDemand.R
+++ b/R/toolAdjustEsDemand.R
@@ -6,11 +6,11 @@
 #' @param mapIso2region map iso countries to regions
 #' @param completeData All combinations of region, period, univocalName and technology in EDGE-T decision tree
 #' @param filter list of filters for specific branches in the upper decision tree, containing all associated
-#' @param data source data containing the annual mileage and load factor
+#' @param histSourceData the full source data containing the annual mileage and load factor
 #' univocalNames
 #' @return a quitte object
 
-toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, data) {
+toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSourceData) {
   variable <- period  <- unit <- value <-  demldv <- regionCode21 <-
     regionCode12 <- region <- univocalName <- NULL
 
@@ -51,66 +51,65 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, data) {
   dt[region %in% c("CHN", "HKG", "MAC") & univocalName == "Truck (18t)", value := value / 2,
      by = c("period", "region", "technology")]
 
-  ######## new China stuff from Robert
+
+  ######## new China truck size adjustment from Robert
+
+  ## Adjustments on truck size classes in CHN region according to newer data.
+  ## This data is based on downscaled values from CEIC data, https://www.ceicdata.com/en/china/no-of-motor-vehicle/cn-no-of-motor-vehicle-truck-heavy
+  ## It is further split to EDGE-T size classes : 40t	5%, 26t	9%, 18t	11%, 7.5t	14%, 0-3.5 t 61%
+  ## The original data and the further processing can be found in the transport folder in the owncloud:
+  ## "Data/RegionalData/compiling_CHA_data_heavy_duty_vehicles.xlsx", cells V17:V21
+
+  # First step: define target vehicle shares by size:
+  VehSharesTargetSize <- data.table(univocalName = c("Truck (0-3_5t)","Truck (18t)","Truck (26t)","Truck (40t)","Truck (7_5t)"),
+                                    region = "CHN",
+                                    variable = "Share_in_Vehicles",
+                                    unit = "Percent",
+                                    value = c(61,11,9,5,14))
 
 
   # ## For debugging: first create safe-copy to later check if only the wanted rows are changed. Outcomment for debugging.
-  # dt_safecopy <- copy(dt)
+  dt_safecopy <- copy(dt)
 
   # extract existing ES totals for regions and trucks of interest
   histESdemandCHA <- dt[region %in% c("CHN") & univocalName %like% "Truck"]
 
-  histESdemandCHA_old <- histESdemandCHA[    # drop variable and unit
+  histESdemandCHAold <- histESdemandCHA[    # drop variable and unit
     , .(value = sum(value)),
     by = .(region, univocalName, technology, period )
   ]
 
-  histESdemandCHA_old_size <- histESdemandCHA_old[
-    , .(old_ES = sum(value)),
+  histESdemandCHAoldSize <- histESdemandCHAold[
+    , .(oldES = sum(value)),
     by = .(region, univocalName, period)
   ]
 
-  histESdemandCHA_old_total <- histESdemandCHA_old[
+  histESdemandCHAoldTotal <- histESdemandCHAold[
     , .(total_ES = sum(value)),
     by = .(region, period)
   ]
 
   # calculate new ES splits
 
-  ## define target vehicle shares by size:
-  ## this data is based on downscaled values from CEIC data, and further split to EDGE-T splits : 40t	5%, 26t	9%, 18t	11%, 7.5t	23%, 0-3.5 t 52%
-  ## The data can be found in the transport folder in the owncloud: "Data/RegionalData/compiling_CHA_data_heavy_duty_vehicles.xlsx", cells V17:V21
-
-  VehSharesTargetSize <- data.table(univocalName = c("Truck (0-3_5t)","Truck (18t)","Truck (26t)","Truck (40t)","Truck (7_5t)"),
-                                    region = "CHN",
-                                    variable = "Share_in_Vehicles",
-                                    unit = "Percent",
-                                    value = c(52,11,9,5,23))
-
-  ## Then calculate total tkm per vehicle from annual mileage and load factors.
+  ## First calculate total tkm per vehicle from annual mileage and load factors.
   ## Take the values for "Liquids", as that is the most common technology in 2010
 
-  annualTkmPerVehicleCol <- data$annualMileage[region %in% c("CHN") & univocalName %like% "Truck" & period == 2010 & technology == "Liquids",
+  annualTkmPerVehicle <- histSourceData$annualMileage[region %in% c("CHN") & univocalName %like% "Truck" & period == 2010 & technology == "Liquids",
                                           .(annualMileage = value), by = .(region, univocalName)]
 
-  annualTkmPerVehicleCol <- annualTkmPerVehicleCol[data$loadFactor[region %in% c("CHN") & univocalName %like% "Truck" & period == 2010 & technology == "Liquids",
-                                                              .(loadFactor = loadFactor), by = .(region, univocalName)],
-                                                   on = .( univocalName, region)][
-                                                     , load_x_mileage := annualMileage * loadFactor
-                                                   ]
+  annualTkmPerVehicle <- merge(annualTkmPerVehicle, histSourceData$loadFactor[region %in% c("CHN") & univocalName %like% "Truck" & period == 2010 & technology == "Liquids",
+                                                                    .(loadFactor = loadFactor), by = .(region, univocalName)],
+                               by = c("region", "univocalName"))
+
+  annualTkmPerVehicle[, ESperVeh := annualMileage * loadFactor ]
 
 
   ## calculate resulting ES values by size
-  ESSharesTargetSize <- VehSharesTargetSize[
-    annualTkmPerVehicleCol,
-    on = .(univocalName, region)
-  ][
-    , ESsharesUnnormalized := value / 100 * load_x_mileage
-  ]
+  ESSharesTargetSize <- merge(VehSharesTargetSize, annualTkmPerVehicle, by = c("region", "univocalName") )
 
-  ESSharesTargetSize[ , ESsharesNormalized := ESsharesUnnormalized / sum(ESsharesUnnormalized),
-                      by = region
-  ]
+  ESSharesTargetSize[ , ESsharesUnnormalized := value / 100 * ESperVeh ]
+
+  ESSharesTargetSize[ , ESsharesNormalized := ESsharesUnnormalized / sum(ESsharesUnnormalized), by = region ]
 
   ESSharesTargetSizeBack <- ESSharesTargetSize[ , .(univocalName = univocalName ,
                                                     region = region,
@@ -119,58 +118,57 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, data) {
                                                     value = ESsharesNormalized * 100)
   ]
 
-
   # calculate target ES per vehicle size with old ES totals
-  ## First create new DT with period x univocalname size, as SizeSharesTarget has no period, and histESdemandCHA_old_total no size
+  ## First create new DT with period x univocalname size, as SizeSharesTarget has no period, and histESdemandCHAoldTotal no size
 
-  histESdemandCHA_target_size <- CJ(
-    period = histESdemandCHA_old_total$period,
+  histESdemandCHAtargetPerSize <- CJ(
+    period = histESdemandCHAoldTotal$period,
     univocalName = ESSharesTargetSizeBack$univocalName,
     unique = TRUE
   )[
-    ESSharesTargetSizeBack[, .(univocalName, ES_share = value / 100)],
+    ESSharesTargetSizeBack[, .(univocalName, ESshare = value / 100)],
     on = "univocalName"
   ][
-    histESdemandCHA_old_total,
+    histESdemandCHAoldTotal,
     on = "period"
-  ][
-    , target_ES := ES_share * total_ES
   ]
+
+
+  histESdemandCHAtargetPerSize[ , targetES := ESshare * total_ES ]
 
   ## calculate scaling factors for each size
-  ES_scaling <- histESdemandCHA_old_size[
-    histESdemandCHA_target_size,
-    on = .(period, univocalName, region)
-  ][
-    , scaling := target_ES / old_ES
-  ]
+  ESscaling <- merge(histESdemandCHAoldSize, histESdemandCHAtargetPerSize, by = c("period", "univocalName", "region") )
+
+  ESscaling[ , scaling := targetES / oldES ]
 
   ## rescale using old ES totals:
-  histESdemandCHA_newES <- histESdemandCHA_old[
-    ES_scaling,
-    on = .(period, univocalName, region)
-  ][
-    , value := value * scaling
-  ]
+  histESdemandCHAnewES <- merge(histESdemandCHAold, ESscaling, by = c("period", "univocalName", "region") )
+
+  histESdemandCHAnewES[, value := value * scaling ]
 
   ## drop unused columns, add variable and unit
-  histESdemandCHA_newES[, c("old_ES", "ES_share", "total_ES", "target_ES", "scaling") := NULL][, ':='(variable = "ES", unit = "billion tkm/yr")]
+  histESdemandCHAnewES[, c("oldES", "ESshare", "total_ES", "targetES", "scaling") := NULL][, ':='(variable = "ES", unit = "billion tkm/yr")]
 
   ## check that the total new ES and the total old ES are unchanged:
+
+  setkey(histESdemandCHAnewES,region)
+  setkey(histESdemandCHAold,region)
+
   stopifnot(
     all.equal(
-      histESdemandCHA_newES[, sum(value), by = period],
-      histESdemandCHA[, sum(value), by = period]
+      histESdemandCHAnewES[, sum(value), by = period],
+      histESdemandCHAold[, sum(value), by = period]
     )
   )
 
-  ## overwrite the data in dt:
+  ## update the original dt
+  ## the "value := i.value" formulation overwrites only the rows in dt that are contained in histESdemandCHAnewES, and keeps everyhting else unchanged:
 
-  join_cols <- c("region", "univocalName", "technology", "variable","unit", "period")
+  joinCols <- c("region", "univocalName", "technology", "variable","unit", "period")
 
   dt[
-    histESdemandCHA_newES,
-    on = join_cols,
+    histESdemandCHAnewES,
+    on = joinCols,
     value := i.value
   ]
 
@@ -194,12 +192,6 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, data) {
   #   )
   # ]
   # dt_changed <- dt_diff[value_new != value_old]
-
-  ## is it necessary / advised to clean up, or is this anyway all deleted because the function only returns dt ??
-  histESdemandCHA        <- NULL
-  histESdemandCHA_newES  <- NULL
-  histESdemandCHA_target_size <- NULL
-  ESSharesTargetSize    <- NULL
 
   ############ end of new CHA stuff from Robert
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.12.6**
+R package **mrtransport**, version **0.12.7**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrtransport)](https://cran.r-project.org/package=mrtransport) [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.12.6, <https://github.com/pik-piam/mrtransport>.
+Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.12.7, <https://github.com/pik-piam/mrtransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -50,6 +50,6 @@ A BibTeX entry for LaTeX users is
   date = {2026-02-06},
   year = {2026},
   url = {https://github.com/pik-piam/mrtransport},
-  note = {Version: 0.12.6},
+  note = {Version: 0.12.7},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.13.1**
+R package **mrtransport**, version **0.13.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrtransport)](https://cran.r-project.org/package=mrtransport) [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.13.1, <https://github.com/pik-piam/mrtransport>.
+Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.13.3, <https://github.com/pik-piam/mrtransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -50,6 +50,6 @@ A BibTeX entry for LaTeX users is
   date = {2026-02-10},
   year = {2026},
   url = {https://github.com/pik-piam/mrtransport},
-  note = {Version: 0.13.1},
+  note = {Version: 0.13.3},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.12.5**
+R package **mrtransport**, version **0.12.6**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrtransport)](https://cran.r-project.org/package=mrtransport) [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.12.5, <https://github.com/pik-piam/mrtransport>.
+Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.12.6, <https://github.com/pik-piam/mrtransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -50,6 +50,6 @@ A BibTeX entry for LaTeX users is
   date = {2026-02-06},
   year = {2026},
   url = {https://github.com/pik-piam/mrtransport},
-  note = {Version: 0.12.5},
+  note = {Version: 0.12.6},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.13.0**
+R package **mrtransport**, version **0.13.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrtransport)](https://cran.r-project.org/package=mrtransport) [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.13.0, <https://github.com/pik-piam/mrtransport>.
+Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.13.1, <https://github.com/pik-piam/mrtransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,9 +47,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrtransport: Input data generation for the EDGE-Transport model},
   author = {Johanna Hoppe and Jarusch Muessel and Alex K. Hagen and Alois Dirnaichner},
-  date = {2026-02-09},
+  date = {2026-02-10},
   year = {2026},
   url = {https://github.com/pik-piam/mrtransport},
-  note = {Version: 0.13.0},
+  note = {Version: 0.13.1},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.12.4**
+R package **mrtransport**, version **0.12.5**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrtransport)](https://cran.r-project.org/package=mrtransport) [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.12.4, <https://github.com/pik-piam/mrtransport>.
+Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.12.5, <https://github.com/pik-piam/mrtransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,9 +47,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrtransport: Input data generation for the EDGE-Transport model},
   author = {Johanna Hoppe and Jarusch Muessel and Alex K. Hagen and Alois Dirnaichner},
-  date = {2026-02-04},
+  date = {2026-02-06},
   year = {2026},
   url = {https://github.com/pik-piam/mrtransport},
-  note = {Version: 0.12.4},
+  note = {Version: 0.12.5},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.12.12**
+R package **mrtransport**, version **0.12.13**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrtransport)](https://cran.r-project.org/package=mrtransport) [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.12.12, <https://github.com/pik-piam/mrtransport>.
+Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.12.13, <https://github.com/pik-piam/mrtransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,9 +47,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrtransport: Input data generation for the EDGE-Transport model},
   author = {Johanna Hoppe and Jarusch Muessel and Alex K. Hagen and Alois Dirnaichner},
-  date = {2026-02-07},
+  date = {2026-02-09},
   year = {2026},
   url = {https://github.com/pik-piam/mrtransport},
-  note = {Version: 0.12.12},
+  note = {Version: 0.12.13},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.12.1**
+R package **mrtransport**, version **0.12.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrtransport)](https://cran.r-project.org/package=mrtransport) [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel J, Hagen A, Dirnaichner A (2025). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.12.1, <https://github.com/pik-piam/mrtransport>.
+Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.12.4, <https://github.com/pik-piam/mrtransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,9 +47,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrtransport: Input data generation for the EDGE-Transport model},
   author = {Johanna Hoppe and Jarusch Muessel and Alex K. Hagen and Alois Dirnaichner},
-  date = {2025-10-22},
-  year = {2025},
+  date = {2026-02-04},
+  year = {2026},
   url = {https://github.com/pik-piam/mrtransport},
-  note = {Version: 0.12.1},
+  note = {Version: 0.12.4},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.12.7**
+R package **mrtransport**, version **0.12.8**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrtransport)](https://cran.r-project.org/package=mrtransport) [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.12.7, <https://github.com/pik-piam/mrtransport>.
+Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.12.8, <https://github.com/pik-piam/mrtransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -50,6 +50,6 @@ A BibTeX entry for LaTeX users is
   date = {2026-02-06},
   year = {2026},
   url = {https://github.com/pik-piam/mrtransport},
-  note = {Version: 0.12.7},
+  note = {Version: 0.12.8},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.12.9**
+R package **mrtransport**, version **0.12.10**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrtransport)](https://cran.r-project.org/package=mrtransport) [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.12.9, <https://github.com/pik-piam/mrtransport>.
+Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.12.10, <https://github.com/pik-piam/mrtransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,9 +47,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrtransport: Input data generation for the EDGE-Transport model},
   author = {Johanna Hoppe and Jarusch Muessel and Alex K. Hagen and Alois Dirnaichner},
-  date = {2026-02-06},
+  date = {2026-02-07},
   year = {2026},
   url = {https://github.com/pik-piam/mrtransport},
-  note = {Version: 0.12.9},
+  note = {Version: 0.12.10},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.12.10**
+R package **mrtransport**, version **0.12.12**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrtransport)](https://cran.r-project.org/package=mrtransport) [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.12.10, <https://github.com/pik-piam/mrtransport>.
+Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.12.12, <https://github.com/pik-piam/mrtransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -50,6 +50,6 @@ A BibTeX entry for LaTeX users is
   date = {2026-02-07},
   year = {2026},
   url = {https://github.com/pik-piam/mrtransport},
-  note = {Version: 0.12.10},
+  note = {Version: 0.12.12},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.12.14**
+R package **mrtransport**, version **0.13.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrtransport)](https://cran.r-project.org/package=mrtransport) [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.12.14, <https://github.com/pik-piam/mrtransport>.
+Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.13.0, <https://github.com/pik-piam/mrtransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -50,6 +50,6 @@ A BibTeX entry for LaTeX users is
   date = {2026-02-09},
   year = {2026},
   url = {https://github.com/pik-piam/mrtransport},
-  note = {Version: 0.12.14},
+  note = {Version: 0.13.0},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.12.8**
+R package **mrtransport**, version **0.12.9**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrtransport)](https://cran.r-project.org/package=mrtransport) [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.12.8, <https://github.com/pik-piam/mrtransport>.
+Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.12.9, <https://github.com/pik-piam/mrtransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -50,6 +50,6 @@ A BibTeX entry for LaTeX users is
   date = {2026-02-06},
   year = {2026},
   url = {https://github.com/pik-piam/mrtransport},
-  note = {Version: 0.12.8},
+  note = {Version: 0.12.9},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.12.13**
+R package **mrtransport**, version **0.12.14**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrtransport)](https://cran.r-project.org/package=mrtransport) [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.12.13, <https://github.com/pik-piam/mrtransport>.
+Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.12.14, <https://github.com/pik-piam/mrtransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -50,6 +50,6 @@ A BibTeX entry for LaTeX users is
   date = {2026-02-09},
   year = {2026},
   url = {https://github.com/pik-piam/mrtransport},
-  note = {Version: 0.12.13},
+  note = {Version: 0.12.14},
 }
 ```

--- a/man/toolAdjustEsDemand.Rd
+++ b/man/toolAdjustEsDemand.Rd
@@ -4,7 +4,7 @@
 \alias{toolAdjustEsDemand}
 \title{Perform parameter specific adjustments on the input data}
 \usage{
-toolAdjustEsDemand(dt, mapIso2region, completeData, filter, data)
+toolAdjustEsDemand(dt, mapIso2region, completeData, filter, histSourceData)
 }
 \arguments{
 \item{dt}{calculated raw data without adjustments}
@@ -15,7 +15,7 @@ toolAdjustEsDemand(dt, mapIso2region, completeData, filter, data)
 
 \item{filter}{list of filters for specific branches in the upper decision tree, containing all associated}
 
-\item{data}{source data containing the annual mileage and load factor
+\item{histSourceData}{the full source data containing the annual mileage and load factor
 univocalNames}
 }
 \value{

--- a/man/toolAdjustEsDemand.Rd
+++ b/man/toolAdjustEsDemand.Rd
@@ -4,7 +4,7 @@
 \alias{toolAdjustEsDemand}
 \title{Perform parameter specific adjustments on the input data}
 \usage{
-toolAdjustEsDemand(dt, mapIso2region, completeData, filter)
+toolAdjustEsDemand(dt, mapIso2region, completeData, filter, data)
 }
 \arguments{
 \item{dt}{calculated raw data without adjustments}
@@ -13,7 +13,9 @@ toolAdjustEsDemand(dt, mapIso2region, completeData, filter)
 
 \item{completeData}{All combinations of region, period, univocalName and technology in EDGE-T decision tree}
 
-\item{filter}{list of filters for specific branches in the upper decision tree, containing all associated
+\item{filter}{list of filters for specific branches in the upper decision tree, containing all associated}
+
+\item{data}{source data containing the annual mileage and load factor
 univocalNames}
 }
 \value{


### PR DESCRIPTION
## Purpose of this PR

Improve the truck numbers in CHA & JPN, improve LDV numbers in CHA. Concretely: 
+ update historic truck ES demands for CHA based on better data on truck numbers by size
+ update historic truck ES demands for JPN
+ update historic LDV ES demands for CHA

## Checklist:

- [x] I used ./test-standard-runs to compare and archive the changes introduced by this PR in /p/projects/edget/PRchangeLog/

## Further information (optional):

* Test runs are here: /p/projects/edget/PRchangeLog/20260210_PR48_change2010truckSizeESdemCHNJPN
* Comparison of results (what changes by this PR?): 

old vs new ES demands: 

```
> histESdemand_old[region == "CHN" & univocalName %like% "Truck" & period == 2010 & technology == "Liquids"]
Key: <region>
   region   univocalName technology variable           unit period    value
   <char>         <char>     <char>   <char>         <char>  <num>    <num>
1:    CHN Truck (0-3_5t)    Liquids       ES billion tkm/yr   2010 451.3677
2:    CHN    Truck (18t)    Liquids       ES billion tkm/yr   2010 312.0577
3:    CHN    Truck (26t)    Liquids       ES billion tkm/yr   2010 156.0288
4:    CHN    Truck (40t)    Liquids       ES billion tkm/yr   2010 156.0288
5:    CHN   Truck (7_5t)    Liquids       ES billion tkm/yr   2010 276.9963
> histESdemandtoUpdatenewES[region == "CHN" & univocalName %like% "Truck" & period == 2010 & technology == "Liquids"]
Key: <region>
   period   univocalName region technology     value variable           unit
    <num>         <char> <char>     <char>     <num>   <char>         <char>
1:   2010 Truck (0-3_5t)    CHN    Liquids  67.84866       ES billion tkm/yr
2:   2010    Truck (18t)    CHN    Liquids 202.92609       ES billion tkm/yr
3:   2010    Truck (26t)    CHN    Liquids 218.15685       ES billion tkm/yr
4:   2010    Truck (40t)    CHN    Liquids 652.20718       ES billion tkm/yr
5:   2010   Truck (7_5t)    CHN    Liquids 207.24415       ES billion tkm/yr
```

and this correctly brings down CHA and JPN truck numbers to reasonable values:

<img width="583" height="886" alt="image" src="https://github.com/user-attachments/assets/a7e6d0dc-9bb4-4261-8d10-743a6a18aea4" />

and brings up CHA car numbers to more realistic values: 

<img width="284" height="834" alt="image" src="https://github.com/user-attachments/assets/8faebe5c-6108-4a29-ad2f-8b4120ade3d9" />


It also changed FE trajectories, as the 2010 FE demands are different and thus get rescaled differently in the IEA FE calibration. Some things got better (passenger:freight road FE split in CHA, which improved from 2:4.5 to a more realistic 5:2.5), while mid-term demand increased above historic levels:

<img width="1071" height="622" alt="image" src="https://github.com/user-attachments/assets/cee98f45-4685-4f30-af94-f1a671e06cb6" />

this will require a follow-up adjustment of ES demand projections in the scenarios


