### PR TITLE
Ariadne updates

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,5 @@
 ^.lintr$
 ^tests/.lintr$
 ^.*CITATION.cff$
+^\.claude$
+^_pkgdown\.yml$

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '27444164496'
+ValidationKey: '2874200'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
@@ -8,3 +8,4 @@ allowLinterWarnings: no
 enforceVersionUpdate: yes
 skipCoverage: no
 AutocreateCITATION: yes
+UsePkgDown: no

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2725702'
+ValidationKey: '27444164496'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.13.3
-date-released: '2026-02-10'
+version: 0.13.3.9001
+date-released: '2026-02-12'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.
 authors:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.13.3.9001
-date-released: '2026-02-12'
+version: 0.14.0
+date-released: '2026-03-18'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.13.3.9001
+Version: 0.14.0
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -34,4 +34,4 @@ Imports:
     tidyselect,
     utils,
     zoo
-Date: 2026-02-12
+Date: 2026-03-18

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.13.3
+Version: 0.13.3.9001
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -34,4 +34,4 @@ Imports:
     tidyselect,
     utils,
     zoo
-Date: 2026-02-10
+Date: 2026-02-12

--- a/R/toolAdjustAnnualMileage.R
+++ b/R/toolAdjustAnnualMileage.R
@@ -67,7 +67,7 @@ toolAdjustAnnualMileage <- function(dt, completeData, filter, ariadneAdjustments
   # c) We do not have vintage tracking for the rest of the modes -> insert zeros
   # Later on it would be great to top up this data
   missingAnnualMileageData <- fread(
-                                    text = "univocalName, annualMileage
+              text = "univocalName, annualMileage
               International Aviation, 0
               Domestic Aviation, 0
               Passenger Rail, 0

--- a/R/toolAdjustAnnualMileage.R
+++ b/R/toolAdjustAnnualMileage.R
@@ -36,6 +36,9 @@ toolAdjustAnnualMileage <- function(dt, completeData, filter, ariadneAdjustments
   dt <- dt[!is.na(check)]
   # update variable and unit for introduced NAs
   dt[, unit := mileageUnit][, variable := "Annual mileage"][, check := NULL]
+  
+  dt[, value := ifelse(is.na(value), value[technology == "Liquids"], value),
+     by = c("period", "univocalName", "region")]
 
   dt[, value := ifelse(is.na(value), mean(value, na.rm = TRUE), value),
      by = c("period", "univocalName", "region")]

--- a/R/toolAdjustAnnualMileage.R
+++ b/R/toolAdjustAnnualMileage.R
@@ -26,10 +26,7 @@ toolAdjustAnnualMileage <- function(dt, completeData, filter, ariadneAdjustments
   #    "The average distance travelled by car has increased between 2021 and 2023 (+3%/year at EU level) after a sharp decrease in 2020 in most countries (-13% at EU level). 
   #    In 2023, it was still under its 2019 level (-4% for the EU)."
   if (ariadneAdjustments) {
-    dt[period == 2020 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.87]
-    dt[period == 2021 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.88]
-    dt[period == 2022 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.89]
-    dt[period >= 2023 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.9]
+    dt[period >= 2020 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.87]
   }
   # 2: Assume missing data
   # a) Some modes and technologies are missing an annual mileage

--- a/R/toolAdjustAnnualMileage.R
+++ b/R/toolAdjustAnnualMileage.R
@@ -15,16 +15,12 @@ toolAdjustAnnualMileage <- function(dt, completeData, filter, ariadneAdjustments
 
   ISOcountriesMap <- system.file("extdata", "regionmappingISOto21to12.csv", package = "mrtransport", mustWork = TRUE)
   ISOcountriesMap <- fread(ISOcountriesMap, skip = 0)
-  
-  # 1: Adjustments made by Alois in consequence of the ARIADNE model intercomparison in 2022: Applying a factor of 0.9
-  #    according to ViZ data from 2020 there has been a 10% reduction wrt 2010 values
-  #    (from 14 kkm to 13.6 kkm per vehicle and year)
-  # 2: Adjustments made by Johanna in consequence of the ARIADNE model intercomparison in 2026: 
-  #    Removing the factor, because we are overestimating the vehicle stock in 2005 but meet the energy service demand exactly
-  #    Introducing an annual mileage reduction due to the covid pandemic for EUR countries to match rising vehicle stock reported by EU pocketbook data even with demand dip
-  #    source that documents annual mileage dip due to covid-pandemic: Odyssee-Mure
-  #    "after a sharp decrease in 2020 in most countries (-13% at EU level)" 
-  #    For now we do not assume a mileage recovery in the years after 2020 (as reported by Odyssee-Mure), because we do no cover the demand dynamics yet (increases again after 2022).
+
+  # 1: Adjustments made by Johanna in consequence of the ARIADNE model intercomparison in 2026:
+  #    Introducing an annual mileage reduction due to the covid pandemic for EUR countries to match rising vehicle stock reported by EU pocketbook data even with demand dip.
+  #    source that documents annual mileage dip due to covid-pandemic: Odyssee-Mure "after a sharp decrease in 2020 in most countries (-13% at EU level)"
+  #    For now we do not assume a mileage recovery in the years after 2020 (as reported by Odyssee-Mure), because we do no cover the energy service demand
+  #    dynamics yet sufficiently (increases again after 2022).
   #    To get closer to the reported vehicle stock increase (EU pocket book data) we keep the annual mileage reduction
   if (ariadneAdjustments) {
     dt[period >= 2020 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.87]
@@ -105,8 +101,7 @@ toolAdjustAnnualMileage <- function(dt, completeData, filter, ariadneAdjustments
   dt <- dt[period == 1990 | period > 2010]
   dt <- rmndt::approx_dt(dt, xdata, "period", "value")
 
-  # c) In the scenarioMIP validation we decided to only use constant annual mileage values
-  # until we have better data (this makes 3b obsolete)
+  # c) Until we have better data, we keep the values konstant after 2030
   dt <- dt[period >= 2030, value := value[period == 2030], by = setdiff(names(dt), c("value", "period"))]
   return(dt)
 }

--- a/R/toolAdjustAnnualMileage.R
+++ b/R/toolAdjustAnnualMileage.R
@@ -22,9 +22,10 @@ toolAdjustAnnualMileage <- function(dt, completeData, filter, ariadneAdjustments
   # 2: Adjustments made by Johanna in consequence of the ARIADNE model intercomparison in 2026: 
   #    Removing the factor, because we are overestimating the vehicle stock in 2005 but meet the energy service demand exactly
   #    Introducing an annual mileage reduction due to the covid pandemic for EUR countries to match rising vehicle stock reported by EU pocketbook data even with demand dip
-  #    source: Odyssee-Mure
-  #    "The average distance travelled by car has increased between 2021 and 2023 (+3%/year at EU level) after a sharp decrease in 2020 in most countries (-13% at EU level). 
-  #    In 2023, it was still under its 2019 level (-4% for the EU)."
+  #    source that documents annual mileage dip due to covid-pandemic: Odyssee-Mure
+  #    "after a sharp decrease in 2020 in most countries (-13% at EU level)" 
+  #    For now we do not assume a mileage recovery in the years after 2020 (as reported by Odyssee-Mure), because we do no cover the demand dynamics yet (increases again after 2022).
+  #    To get closer to the reported vehicle stock increase (EU pocket book data) we keep the annual mileage reduction
   if (ariadneAdjustments) {
     dt[period >= 2020 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.87]
   }

--- a/R/toolAdjustAnnualMileage.R
+++ b/R/toolAdjustAnnualMileage.R
@@ -13,10 +13,12 @@ toolAdjustAnnualMileage <- function(dt, completeData, filter, ariadneAdjustments
   region <- value <- univocalName <- check <- unit <- variable <- annualMileage <- period <- technology <- meanValue <-
     regionCode21 <- . <- NULL
 
-  # 1: Adjustments made by Alois in consequence of the ARIADNE model intercomparison in 2022
+  # 1: Adjustments made by Alois in consequence of the ARIADNE model intercomparison in 2022: Applying a factor of 0.9
+  #    according to ViZ data from 2020 there has been a 10% reduction wrt 2010 values
+  #    (from 14 kkm to 13.6 kkm per vehicle and year)
+  # 2: Adjustments made by Johanna in consequence of the ARIADNE model intercomparison in 2026: Changing the factor to 0.8, because we are underestimating the vehicle stock
   if (ariadneAdjustments) {
-    ## according to ViZ data from 2020 there has been a 10% reduction wrt 2010 values
-    ## (from 14 kkm to 13.6 kkm per vehicle and year)
+    
     dt[region == "DEU" & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.9]
   }
   # 2: Assume missing data

--- a/R/toolAdjustAnnualMileage.R
+++ b/R/toolAdjustAnnualMileage.R
@@ -21,7 +21,10 @@ toolAdjustAnnualMileage <- function(dt, completeData, filter, ariadneAdjustments
   #    (from 14 kkm to 13.6 kkm per vehicle and year)
   # 2: Adjustments made by Johanna in consequence of the ARIADNE model intercomparison in 2026: 
   #    Removing the factor, because we are overestimating the vehicle stock in 2005 but meet the energy service demand exactly
-  #    Introducing an annual mileage reduction due to the covid pandemic (only in DEU for now) to match rising vehicle stock reported by EU pocketbook data even with demand dip
+  #    Introducing an annual mileage reduction due to the covid pandemic for EUR countries to match rising vehicle stock reported by EU pocketbook data even with demand dip
+  #    source: Odyssee-Mure
+  #    "The average distance travelled by car has increased between 2021 and 2023 (+3%/year at EU level) after a sharp decrease in 2020 in most countries (-13% at EU level). 
+  #    In 2023, it was still under its 2019 level (-4% for the EU)."
   if (ariadneAdjustments) {
     dt[period == 2020 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.87]
     dt[period == 2021 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.9]

--- a/R/toolAdjustAnnualMileage.R
+++ b/R/toolAdjustAnnualMileage.R
@@ -23,11 +23,10 @@ toolAdjustAnnualMileage <- function(dt, completeData, filter, ariadneAdjustments
   #    Removing the factor, because we are overestimating the vehicle stock in 2005 but meet the energy service demand exactly
   #    Introducing an annual mileage reduction due to the covid pandemic (only in DEU for now) to match rising vehicle stock reported by EU pocketbook data even with demand dip
   if (ariadneAdjustments) {
-    dt[period == 2020 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.5]
-    dt[period == 2021 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.6]
-    dt[period == 2022 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.7]
-    dt[period == 2023 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.8]
-    dt[period == 2024 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.9]
+    dt[period == 2020 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.87]
+    dt[period == 2021 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.9]
+    dt[period == 2022 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.93]
+    dt[period >= 2023 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.96]
   }
   # 2: Assume missing data
   # a) Some modes and technologies are missing an annual mileage
@@ -107,7 +106,6 @@ toolAdjustAnnualMileage <- function(dt, completeData, filter, ariadneAdjustments
 
   # c) In the scenarioMIP validation we decided to only use constant annual mileage values
   # until we have better data (this makes 3b obsolete)
-  dt <- dt[, value := value[period == 2030], by = setdiff(names(dt), c("value", "period"))]
-
+  dt <- dt[period >= 2030, value := value[period == 2030], by = setdiff(names(dt), c("value", "period"))]
   return(dt)
 }

--- a/R/toolAdjustAnnualMileage.R
+++ b/R/toolAdjustAnnualMileage.R
@@ -13,13 +13,20 @@ toolAdjustAnnualMileage <- function(dt, completeData, filter, ariadneAdjustments
   region <- value <- univocalName <- check <- unit <- variable <- annualMileage <- period <- technology <- meanValue <-
     regionCode21 <- . <- NULL
 
+  ISOcountriesMap <- system.file("extdata", "regionmappingISOto21to12.csv", package = "mrtransport", mustWork = TRUE)
+  ISOcountriesMap <- fread(ISOcountriesMap, skip = 0)
+  
   # 1: Adjustments made by Alois in consequence of the ARIADNE model intercomparison in 2022: Applying a factor of 0.9
   #    according to ViZ data from 2020 there has been a 10% reduction wrt 2010 values
   #    (from 14 kkm to 13.6 kkm per vehicle and year)
-  # 2: Adjustments made by Johanna in consequence of the ARIADNE model intercomparison in 2026: Changing the factor to 0.8, because we are underestimating the vehicle stock
+  # 2: Adjustments made by Johanna in consequence of the ARIADNE model intercomparison in 2026: 
+  #    Removing the factor, because we are overestimating the vehicle stock in 2005 but meet the energy service demand exactly
+  #    Introducing an annual mileage reduction due to the covid pandemic (only in DEU for now) to match rising vehicle stock reported by EU pocketbook data even with demand dip
   if (ariadneAdjustments) {
-    
-    dt[region == "DEU" & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.9]
+    dt[period == 2020 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.7]
+    dt[period == 2021 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.75]
+    dt[period == 2022 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.8]
+    dt[period == 2023 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.9]
   }
   # 2: Assume missing data
   # a) Some modes and technologies are missing an annual mileage
@@ -38,8 +45,9 @@ toolAdjustAnnualMileage <- function(dt, completeData, filter, ariadneAdjustments
   dt <- dt[!is.na(check)]
   # update variable and unit for introduced NAs
   dt[, unit := mileageUnit][, variable := "Annual mileage"][, check := NULL]
-  
-  dt[, value := ifelse(is.na(value), value[technology == "Liquids"], value),
+  # By averaging the annual mileage over gases and liquids vehicles to fill gaps for BEVs, BEVs get a higher annual mileage than the ICE cars
+  # Fixing that only for DEU results for now
+  dt[region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode, value := ifelse(is.na(value), value[technology == "Liquids"], value),
      by = c("period", "univocalName", "region")]
 
   dt[, value := ifelse(is.na(value), mean(value, na.rm = TRUE), value),
@@ -57,7 +65,7 @@ toolAdjustAnnualMileage <- function(dt, completeData, filter, ariadneAdjustments
   # b) Annual Mileage for Trucks is missing completely - insert assumptions made by Alois in 2022
   # (probably from ARIADNE)
   annualMileageTrucks <- fread(
-                               text = "univocalName, annualMileage
+      text = "univocalName, annualMileage
               Truck (0-3_5t), 21500
               Truck (7_5t), 34500
               Truck (18t), 53000
@@ -82,8 +90,6 @@ toolAdjustAnnualMileage <- function(dt, completeData, filter, ariadneAdjustments
 
   # 3 adjustments for scenarioMIP validation
   # a) adjust outliers to global mean
-  ISOcountriesMap <- system.file("extdata", "regionmappingISOto21to12.csv", package = "mrtransport", mustWork = TRUE)
-  ISOcountriesMap <- fread(ISOcountriesMap, skip = 0)
   dt[, meanValue := mean(value, na.rm = TRUE), by = c("univocalName", "technology", "period")]
   dt[region %in% ISOcountriesMap[regionCode21 %in% c("NES", "CHA")]$countryCode &
        univocalName %in% filter$trn_pass_road_LDV_4W, value := meanValue]

--- a/R/toolAdjustAnnualMileage.R
+++ b/R/toolAdjustAnnualMileage.R
@@ -27,9 +27,9 @@ toolAdjustAnnualMileage <- function(dt, completeData, filter, ariadneAdjustments
   #    In 2023, it was still under its 2019 level (-4% for the EU)."
   if (ariadneAdjustments) {
     dt[period == 2020 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.87]
-    dt[period == 2021 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.9]
-    dt[period == 2022 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.93]
-    dt[period >= 2023 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.96]
+    dt[period == 2021 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.88]
+    dt[period == 2022 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.89]
+    dt[period >= 2023 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.9]
   }
   # 2: Assume missing data
   # a) Some modes and technologies are missing an annual mileage

--- a/R/toolAdjustAnnualMileage.R
+++ b/R/toolAdjustAnnualMileage.R
@@ -23,10 +23,11 @@ toolAdjustAnnualMileage <- function(dt, completeData, filter, ariadneAdjustments
   #    Removing the factor, because we are overestimating the vehicle stock in 2005 but meet the energy service demand exactly
   #    Introducing an annual mileage reduction due to the covid pandemic (only in DEU for now) to match rising vehicle stock reported by EU pocketbook data even with demand dip
   if (ariadneAdjustments) {
-    dt[period == 2020 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.7]
-    dt[period == 2021 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.75]
-    dt[period == 2022 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.8]
-    dt[period == 2023 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.9]
+    dt[period == 2020 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.5]
+    dt[period == 2021 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.6]
+    dt[period == 2022 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.7]
+    dt[period == 2023 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.8]
+    dt[period == 2024 & region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode & univocalName %in% filter$trn_pass_road_LDV_4W, value := value * 0.9]
   }
   # 2: Assume missing data
   # a) Some modes and technologies are missing an annual mileage

--- a/R/toolAdjustAnnualMileage.R
+++ b/R/toolAdjustAnnualMileage.R
@@ -43,7 +43,7 @@ toolAdjustAnnualMileage <- function(dt, completeData, filter, ariadneAdjustments
   # update variable and unit for introduced NAs
   dt[, unit := mileageUnit][, variable := "Annual mileage"][, check := NULL]
   # By averaging the annual mileage over gases and liquids vehicles to fill gaps for BEVs, BEVs get a higher annual mileage than the ICE cars
-  # Fixing that only for DEU results for now
+  # Fixing that only for EUR countries for now
   dt[region %in% ISOcountriesMap[regionCode12 == "EUR"]$countryCode, value := ifelse(is.na(value), value[technology == "Liquids"], value),
      by = c("period", "univocalName", "region")]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.13.3.9001**
+R package **mrtransport**, version **0.14.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrtransport)](https://cran.r-project.org/package=mrtransport) [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.13.3.9001, <https://github.com/pik-piam/mrtransport>.
+Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.14.0, <https://github.com/pik-piam/mrtransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,9 +47,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrtransport: Input data generation for the EDGE-Transport model},
   author = {Johanna Hoppe and Jarusch Muessel and Alex K. Hagen and Alois Dirnaichner},
-  date = {2026-02-12},
+  date = {2026-03-18},
   year = {2026},
   url = {https://github.com/pik-piam/mrtransport},
-  note = {Version: 0.13.3.9001},
+  note = {Version: 0.14.0},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.13.3**
+R package **mrtransport**, version **0.13.3.9001**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrtransport)](https://cran.r-project.org/package=mrtransport) [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.13.3, <https://github.com/pik-piam/mrtransport>.
+Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.13.3.9001, <https://github.com/pik-piam/mrtransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,9 +47,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrtransport: Input data generation for the EDGE-Transport model},
   author = {Johanna Hoppe and Jarusch Muessel and Alex K. Hagen and Alois Dirnaichner},
-  date = {2026-02-10},
+  date = {2026-02-12},
   year = {2026},
   url = {https://github.com/pik-piam/mrtransport},
-  note = {Version: 0.13.3},
+  note = {Version: 0.13.3.9001},
 }
 ```


### PR DESCRIPTION
## Purpose of this PR
Data updates to better represent short-term trends for Ariadne.

The following corrections have been applied in toolAdjustAnnualMileage()
1. Previously missing BEV mileages (TRACCS countries EUR and NEU in edget) have been filled by averages of other technologies. Because of the significantly higher mileage of gases vehicles, BEVs also received a significantly higher annual mileage than ICE cars. That led to the effect, that the vehicle stock shrinked the more  BEV entered the stock. EUR BEVs now receive the same annual mileage as ICE cars. -> This changes the TCO and makes BEVs less attractive. That is why the edgeTransport PR is needed to readjust the technology shares
2. A covid dip in the annual mileage has been implemented for the years 2020 and higher (see in-code documentation and attached source that can be also found in /p/projects/edget/adjustmentDataFiles/Annual mileage
[transport-eu_Odyssee-Mure.pdf](https://github.com/user-attachments/files/26095960/transport-eu_Odyssee-Mure.pdf)
4. Scenario mip fix to keep annual mileage constant on 2030 levels has been shifted to affect only years after 2030

## Checklist:

- [x ] I used ./test-standard-runs to compare and archive the changes introduced by this PR in /p/projects/edget/PRchangeLog/

## Further information (optional):
Adjustmens in technology shares needed due to change in BEV TCO with annual mileage changes
[edgeTransport PR](https://github.com/pik-piam/edgeTransport/pull/396)

* Test runs are here: /p/projects/edget/PRchangeLog/20260318_UpdatedPRTestAriadneUpdates
* Comparison of results (what changes by this PR?): 
See [edgeTransport PR](https://github.com/pik-piam/edgeTransport/pull/396)

