### PR TITLE
fix warning from inputData generation

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3292960'
+ValidationKey: '3319337'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -11,42 +11,22 @@ jobs:
   check:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
+    container:
+      image: ghcr.io/pik-piam/ci-image:latest
 
     steps:
       - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      # We fix this to 4.5, as currently, pre-commit hooks do not
-      # work reliably with 4.6 because of Rcpp not building reliably
-      # on 4.6. When this is resolved, the version constraint should
-      # be removed again.
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-          extra-repositories: "https://rse.pik-potsdam.de/r/packages"
-          r-version: 4.5
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: |
-            lucode2
-            covr
-            madrat
-            magclass
-            citation
-            gms
-            goxygen
-            GDPuc
-          # piam packages also available on CRAN (madrat, magclass, citation,
-          # gms, goxygen, GDPuc) will usually have an outdated binary version
-          # available; by using extra-packages we get the newest version
+      - name: Install package and dependencies
+        shell: Rscript {0}
+        run: |
+          options(repos = c(pikpiam = 'https://pik-piam.r-universe.dev',
+                            CRAN = Sys.getenv('RSPM')))
+          pak::pak()
 
       - name: Run pre-commit checks
         shell: bash
         run: |
-          python -m pip install pre-commit
-          python -m pip freeze --local
           pre-commit run --show-diff-on-failure --color=always --all-files
 
       - name: Verify validation key

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.16.0
-date-released: '2026-05-08'
+version: 0.16.1
+date-released: '2026-06-13'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.16.0
+Version: 0.16.1
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -34,4 +34,4 @@ Imports:
     tidyselect,
     utils,
     zoo
-Date: 2026-05-08
+Date: 2026-06-13

--- a/R/toolAdjustEsDemand.R
+++ b/R/toolAdjustEsDemand.R
@@ -73,8 +73,8 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
   # These are shares of *vehicle count*, not ES. ES shares are derived below
   # by weighting by annual tkm per vehicle (mileage × load factor).
   targetVehicleShares <- data.table(
-    univocalName = rep(TRUCK_SIZES, 4),
-    region       = rep(REGIONS_TO_FIX, each = 5),
+    univocalName = rep(TRUCK_SIZES, length(TRUCK_SIZES)),
+    region       = rep(REGIONS_TO_FIX, each = length(TRUCK_SIZES)),
     value        = c(
       rep(c(76, 13, 5, 3, 3), 3),  # CHN, HKG, MAC
       c(88,  9, 1, 1, 1),       # JPN

--- a/R/toolAdjustEsDemand.R
+++ b/R/toolAdjustEsDemand.R
@@ -121,6 +121,11 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
   # Step 5: Convert target vehicle shares → target ES shares
   # ES share ∝ vehicle share × ES per vehicle. Normalise within each region.
 
+  #test whether row dimension matches: REGIONS_TO_FIX x TRUCK_SIZES = 5 x 5 = 25 rows
+  if (nrow(targetVehicleShares) != nrow(annualTkmPerVehicle)) {
+    stop("Mismatch in number of rows between target vehicle shares and annual tkm per vehicle data.")
+  }
+
   targetESshares <- merge(targetVehicleShares, annualTkmPerVehicle,
                           by = c("region", "univocalName"))
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.16.0**
+R package **mrtransport**, version **0.16.1**
 
    [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -21,13 +21,13 @@ The additional repository can be made available permanently by adding the line a
 
 After that the most recent version of the package can be installed using `install.packages`:
 
-```r 
+```r
 install.packages("mrtransport")
 ```
 
 Package updates can be installed using `update.packages` (make sure that the additional repository has been added before running that command):
 
-```r 
+```r
 update.packages()
 ```
 
@@ -39,15 +39,15 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model - Version 0.16.0."
+Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model - Version 0.16.1."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {mrtransport: Input data generation for the EDGE-Transport model - Version 0.16.0},
+  title = {mrtransport: Input data generation for the EDGE-Transport model - Version 0.16.1},
   author = {Johanna Hoppe and Jarusch Muessel and Alex K. Hagen and Alois Dirnaichner},
-  date = {2026-05-08},
+  date = {2026-06-13},
   year = {2026},
 }
 ```


### PR DESCRIPTION
## Purpose of this PR
[This ](https://github.com/pik-piam/mrtransport/pull/51)PR introduced a [new ](https://github.com/remindmodel/development_issues/issues/761#event-26473584635) warning during input data generation. The issue was that a data.table was created with the wrong dimensions. I solved the issue (hard-coded numbers) in `toolAdjustESdemand` and added a test that returns an error message, in case this would happen again.

`calcOutput(type = "EdgeTransportSAinputs", warnNA = FALSE, regionmapping = "regionmapping_21_EU11.csv", subtype = "histESdemand", SSPscen = "SSP2")`

produced the warning: 

`~~~~~ Item 1 has 20 rows but longest item has 25; recycled with remainder.`

## Checklist:

- [X] I used ./test-standard-runs to compare and archive the changes introduced by this PR in /p/projects/edget/PRchangeLog/

## Further information (optional):

* Test runs are here:  `/p/projects/edget/PRchangeLog/20260623_xmrTransportFix2` 
They show no differences, as it's supposed to be.


