### PR TITLE
Increase histES 2010 India 

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3342222'
+ValidationKey: '3363831'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3363831'
+ValidationKey: '3384468'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.16.2
-date-released: '2026-06-27'
+version: 0.16.3
+date-released: '2026-07-03'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.
 authors:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrtransport: Input data generation for the EDGE-Transport model'
-version: 0.16.3
+version: 0.16.4
 date-released: '2026-07-03'
 abstract: The mrtransport package contains data preprocessing for the EDGE-Transport
   model.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.16.3
+Version: 0.16.4
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrtransport
 Title: Input data generation for the EDGE-Transport model
-Version: 0.16.2
+Version: 0.16.3
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -33,5 +33,6 @@ Imports:
     tidyselect,
     utils,
     zoo
-Date: 2026-06-27
+Date: 2026-07-03
 Config/roxygen2/version: 8.0.0
+RoxygenNote: 7.3.3

--- a/R/toolAdjustEsDemand.R
+++ b/R/toolAdjustEsDemand.R
@@ -29,8 +29,8 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
   # /03_Paladugula.pdf and
   # /10_ceewGCAM_outlook.pdf
   # Note that I used the upper bound because our Energy Intensities beyond 2010 lead to higher FE than the IEA projects
-  targetPassES2010    <- 5300  # billion pkm
-  targetFreightES2010 <- 2000  # billion tkm
+  targetPassES2010    <- 5400  # billion pkm
+  targetFreightES2010 <- 2300  # billion tkm
   pass_sm2010 <- dt[region == "IND" & period %in% c(2010) & univocalName %in% filter$trn_pass,
      sum(value, na.rm = TRUE)]
   freight_sm2010 <- dt[region == "IND" & period %in% c(2010) & univocalName %in% filter$trn_freight,

--- a/R/toolAdjustEsDemand.R
+++ b/R/toolAdjustEsDemand.R
@@ -23,6 +23,20 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
   dt[is.na(value), variable := "ES"]
   dt <- merge.data.table(dt, mapIso2region, by = "region", all.x = TRUE, allow.cartesian = TRUE)
 
+  # plausibilityFix_IND #plausibilityFix_Pass #plausibilityFix_Freight
+  # Scale India 2010 energy service demand up to plausible totals.
+  # Sources for the target values are:p/projects/edget/adjustmentDataFiles/IND_validation/July26/Literature
+  # /03_Paladugula.pdf and
+  # /10_ceewGCAM_outlook.pdf
+  # Note that I used the upper bound because our Energy Intensities beyond 2010 lead to higher FE than the IEA projects
+  targetPassES2010    <- 5200  # billion pkm
+  targetFreightES2010 <- 2000  # billion tkm
+  dt[region == "IND" & period %in% c(2005, 2010) & univocalName %in% filter$trn_pass,
+     value := value * targetPassES2010 / sum(value, na.rm = TRUE)]
+  dt[region == "IND" & period %in% c(2005, 2010) & univocalName %in% filter$trn_freight,
+     value := value * targetFreightES2010 / sum(value, na.rm = TRUE)]
+
+
   # 1: Some Truck types, Rail, alternative technologies and active modes are lacking energy service demand data
   # The missing modes get a zero demand for now. After the regional aggregation, the zero demand remains only
   # for alternative technologies

--- a/R/toolAdjustEsDemand.R
+++ b/R/toolAdjustEsDemand.R
@@ -29,12 +29,17 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
   # /03_Paladugula.pdf and
   # /10_ceewGCAM_outlook.pdf
   # Note that I used the upper bound because our Energy Intensities beyond 2010 lead to higher FE than the IEA projects
-  targetPassES2010    <- 5200  # billion pkm
+  targetPassES2010    <- 5300  # billion pkm
   targetFreightES2010 <- 2000  # billion tkm
+  pass_sm2010 <- dt[region == "IND" & period %in% c(2010) & univocalName %in% filter$trn_pass,
+     sum(value, na.rm = TRUE)]
+  freight_sm2010 <- dt[region == "IND" & period %in% c(2010) & univocalName %in% filter$trn_freight,
+     sum(value, na.rm = TRUE)]
+
   dt[region == "IND" & period %in% c(2005, 2010) & univocalName %in% filter$trn_pass,
-     value := value * targetPassES2010 / sum(value, na.rm = TRUE)]
+     value := value * targetPassES2010 / pass_sm2010]
   dt[region == "IND" & period %in% c(2005, 2010) & univocalName %in% filter$trn_freight,
-     value := value * targetFreightES2010 / sum(value, na.rm = TRUE)]
+     value := value * targetFreightES2010 / freight_sm2010]
 
 
   # 1: Some Truck types, Rail, alternative technologies and active modes are lacking energy service demand data

--- a/R/toolAdjustEsDemand.R
+++ b/R/toolAdjustEsDemand.R
@@ -23,23 +23,7 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
   dt[is.na(value), variable := "ES"]
   dt <- merge.data.table(dt, mapIso2region, by = "region", all.x = TRUE, allow.cartesian = TRUE)
 
-  # plausibilityFix_IND #plausibilityFix_Pass #plausibilityFix_Freight
-  # Scale India 2010 energy service demand up to plausible totals.
-  # Sources for the target values are:p/projects/edget/adjustmentDataFiles/IND_validation/July26/Literature
-  # /03_Paladugula.pdf and
-  # /10_ceewGCAM_outlook.pdf
-  # Note that I used the upper bound because our Energy Intensities beyond 2010 lead to higher FE than the IEA projects
-  targetPassES2010    <- 5400  # billion pkm
-  targetFreightES2010 <- 2300  # billion tkm
-  pass_sm2010 <- dt[region == "IND" & period %in% c(2010) & univocalName %in% filter$trn_pass,
-     sum(value, na.rm = TRUE)]
-  freight_sm2010 <- dt[region == "IND" & period %in% c(2010) & univocalName %in% filter$trn_freight,
-     sum(value, na.rm = TRUE)]
 
-  dt[region == "IND" & period %in% c(2005, 2010) & univocalName %in% filter$trn_pass,
-     value := value * targetPassES2010 / pass_sm2010]
-  dt[region == "IND" & period %in% c(2005, 2010) & univocalName %in% filter$trn_freight,
-     value := value * targetFreightES2010 / freight_sm2010]
 
 
   # 1: Some Truck types, Rail, alternative technologies and active modes are lacking energy service demand data
@@ -253,6 +237,24 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
   # (the shares are roughly OK)
   dt[region == "DEU" & univocalName %in% filter$trn_freight, value := value * 620 / 587]
   dt[, c("countryName", "regionCode21", "regionCode12", "check") := NULL]
+
+    # plausibilityFix_IND #plausibilityFix_Pass #plausibilityFix_Freight
+  # Scale India 2010 energy service demand up to plausible totals.
+  # Sources for the target values are:p/projects/edget/adjustmentDataFiles/IND_validation/July26/Literature
+  # /03_Paladugula.pdf and
+  # /10_ceewGCAM_outlook.pdf
+  # Note that I used the upper bound because our Energy Intensities beyond 2010 lead to higher FE than the IEA projects
+  targetPassES2010    <- 5400  # billion pkm
+  targetFreightES2010 <- 2300  # billion tkm
+  pass_sm2010 <- dt[region == "IND" & period %in% c(2010) & univocalName %in% filter$trn_pass,
+     sum(value, na.rm = TRUE)]
+  freight_sm2010 <- dt[region == "IND" & period %in% c(2010) & univocalName %in% filter$trn_freight,
+     sum(value, na.rm = TRUE)]
+
+  dt[region == "IND" & period %in% c(2005, 2010) & univocalName %in% filter$trn_pass,
+     value := value * 1.4] #targetPassES2010 / pass_sm2010]
+  dt[region == "IND" & period %in% c(2005, 2010) & univocalName %in% filter$trn_freight,
+     value := value *1.4] #* targetFreightES2010 / freight_sm2010]
 
   return(dt)
 }

--- a/R/toolAdjustEsDemand.R
+++ b/R/toolAdjustEsDemand.R
@@ -238,23 +238,23 @@ toolAdjustEsDemand <- function(dt, mapIso2region, completeData, filter, histSour
   dt[region == "DEU" & univocalName %in% filter$trn_freight, value := value * 620 / 587]
   dt[, c("countryName", "regionCode21", "regionCode12", "check") := NULL]
 
-    # plausibilityFix_IND #plausibilityFix_Pass #plausibilityFix_Freight
+  # plausibilityFix_IND #plausibilityFix_Pass #plausibilityFix_Freight
   # Scale India 2010 energy service demand up to plausible totals.
   # Sources for the target values are:p/projects/edget/adjustmentDataFiles/IND_validation/July26/Literature
   # /03_Paladugula.pdf and
   # /10_ceewGCAM_outlook.pdf
   # Note that I used the upper bound because our Energy Intensities beyond 2010 lead to higher FE than the IEA projects
-  targetPassES2010    <- 5400  # billion pkm
-  targetFreightES2010 <- 2300  # billion tkm
-  pass_sm2010 <- dt[region == "IND" & period %in% c(2010) & univocalName %in% filter$trn_pass,
-     sum(value, na.rm = TRUE)]
-  freight_sm2010 <- dt[region == "IND" & period %in% c(2010) & univocalName %in% filter$trn_freight,
-     sum(value, na.rm = TRUE)]
+  # targetPassES2010    <- 5400   billion pkm
+  # targetFreightES2010 <- 2300   billion tkm
+  # pass_sm2010 <- dt[region == "IND" & period %in% c(2010) & univocalName %in% filter$trn_pass,
+  #   sum(value, na.rm = TRUE)]
+  # freight_sm2010 <- dt[region == "IND" & period %in% c(2010) & univocalName %in% filter$trn_freight,
+  #  sum(value, na.rm = TRUE)]
 
   dt[region == "IND" & period %in% c(2005, 2010) & univocalName %in% filter$trn_pass,
      value := value * 1.4] #targetPassES2010 / pass_sm2010]
   dt[region == "IND" & period %in% c(2005, 2010) & univocalName %in% filter$trn_freight,
-     value := value *1.4] #* targetFreightES2010 / freight_sm2010]
+     value := value * 1.4] #* targetFreightES2010 / freight_sm2010]
 
   return(dt)
 }

--- a/R/toolIEAharmonization.R
+++ b/R/toolIEAharmonization.R
@@ -15,6 +15,9 @@ toolIEAharmonization <- function(...) {
 
   data <- list(...)
   harmonizationYears <- c(1990, 2005, 2010)
+  # While we harmonize for all harmonizationYears, energy intensities >2005 might differ
+  # from the initial harmonized values: Due to a lack of data intenisites were near zero for electric vehicles.
+  # So we reversed the harmonization for such electric road vehicles in 2010.
 
   # Load IEA energy balances data for harmonization [unit: EJ]
   IEAbalMag <- calcOutput(type = "IEAOutputTransport", aggregate = FALSE)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.16.2**
+R package **mrtransport**, version **0.16.3**
 
    [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,17 +39,15 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model." Version: 0.16.2, <https://github.com/pik-piam/mrtransport>.
+Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model - Version 0.16.3."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {mrtransport: Input data generation for the EDGE-Transport model},
+  title = {mrtransport: Input data generation for the EDGE-Transport model - Version 0.16.3},
   author = {Johanna Hoppe and Jarusch Muessel and Alex K. Hagen and Alois Dirnaichner},
-  date = {2026-06-27},
+  date = {2026-07-03},
   year = {2026},
-  url = {https://github.com/pik-piam/mrtransport},
-  note = {Version: 0.16.2},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Input data generation for the EDGE-Transport model
 
-R package **mrtransport**, version **0.16.3**
+R package **mrtransport**, version **0.16.4**
 
    [![R build status](https://github.com/pik-piam/mrtransport/workflows/check/badge.svg)](https://github.com/pik-piam/mrtransport/actions) [![codecov](https://codecov.io/gh/pik-piam/mrtransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrtransport) [![r-universe](https://pik-piam.r-universe.dev/badges/mrtransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,13 +39,13 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **mrtransport** in publications use:
 
-Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model - Version 0.16.3."
+Hoppe J, Muessel J, Hagen A, Dirnaichner A (2026). "mrtransport: Input data generation for the EDGE-Transport model - Version 0.16.4."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {mrtransport: Input data generation for the EDGE-Transport model - Version 0.16.3},
+  title = {mrtransport: Input data generation for the EDGE-Transport model - Version 0.16.4},
   author = {Johanna Hoppe and Jarusch Muessel and Alex K. Hagen and Alois Dirnaichner},
   date = {2026-07-03},
   year = {2026},

--- a/man/mrtransport-package.Rd
+++ b/man/mrtransport-package.Rd
@@ -20,7 +20,6 @@ Useful links:
 
 Authors:
 \itemize{
-  \item Johanna Hoppe \email{johanna.hoppe@pik-potsdam.de} (\href{https://orcid.org/0009-0004-6753-5090}{ORCID})
   \item Jarusch Muessel \email{jarusch.muessel@pik-potsdam.de} (\href{https://orcid.org/0000-0002-1857-7866}{ORCID})
   \item Alex K. Hagen \email{alex.hagen@pik-potsdam.de} (\href{https://orcid.org/0000-0003-4793-8664}{ORCID})
   \item Alois Dirnaichner


### PR DESCRIPTION
## Purpose of this PR
Emissions and FE-Liquids in India are too [high](https://github.com/remindmodel/development_issues/issues/777#event-27473032225), though ES is a bit too low --> I increased ES-2010 to get more efficient modes out of the IEA harmonization. This leads to higher ES demands beyond 2010, which is why I adjusted the trajectory in a corresponding edgeT-[PR](https://github.com/pik-piam/edgeTransport/pull/410). 


## Checklist:

- [x] I used ./test-standard-runs to compare and archive the changes introduced by this PR in /p/projects/edget/PRchangeLog/

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

`/p/projects/edget/PRchangeLog/20260703_India_lowerEnInt`